### PR TITLE
work around https://bugs.openjdk.java.net/browse/JDK-8029147 causing …

### DIFF
--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -970,5 +970,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, TransformLis
 	{
 		painterThread.interrupt();
 		renderingExecutorService.shutdown();
+		state.kill();
+		imageRenderer.kill();
 	}
 }

--- a/src/main/java/bdv/viewer/render/MultiResolutionRenderer.java
+++ b/src/main/java/bdv/viewer/render/MultiResolutionRenderer.java
@@ -583,6 +583,31 @@ public class MultiResolutionRenderer
 		painterThread.requestRepaint();
 	}
 
+	/**
+	 * DON'T USE THIS.
+	 * <p>
+	 * This is a work around for JDK bug
+	 * https://bugs.openjdk.java.net/browse/JDK-8029147 which leads to
+	 * ViewerPanel not being garbage-collected when ViewerFrame is closed. So
+	 * instead we need to manually let go of resources...
+	 */
+	public void kill()
+	{
+		if ( display instanceof TransformAwareBufferedImageOverlayRenderer )
+			( ( TransformAwareBufferedImageOverlayRenderer ) display ).kill();
+		projector = null;
+		renderIdQueue.clear();
+		bufferedImageToRenderId.clear();
+		for ( int i = 0; i < renderImages.length; ++i )
+			renderImages[ i ] = null;
+		for ( int i = 0; i < renderMaskArrays.length; ++i )
+			renderMaskArrays[ i ] = null;
+		for ( int i = 0; i < screenImages.length; ++i )
+			screenImages[ i ] = null;
+		for ( int i = 0; i < bufferedImages.length; ++i )
+			bufferedImages[ i ] = null;
+	}
+
 	private VolatileProjector createProjector(
 			final ViewerState viewerState,
 			final int screenScaleIndex,

--- a/src/main/java/bdv/viewer/render/TransformAwareBufferedImageOverlayRenderer.java
+++ b/src/main/java/bdv/viewer/render/TransformAwareBufferedImageOverlayRenderer.java
@@ -153,4 +153,18 @@ public class TransformAwareBufferedImageOverlayRenderer extends BufferedImageOve
 			paintedTransformListeners.remove( listener );
 		}
 	}
+
+	/**
+	 * DON'T USE THIS.
+	 * <p>
+	 * This is a work around for JDK bug
+	 * https://bugs.openjdk.java.net/browse/JDK-8029147 which leads to
+	 * ViewerPanel not being garbage-collected when ViewerFrame is closed. So
+	 * instead we need to manually let go of resources...
+	 */
+	void kill()
+	{
+		bufferedImage = null;
+		pendingImage = null;
+	}
 }

--- a/src/main/java/bdv/viewer/state/ViewerState.java
+++ b/src/main/java/bdv/viewer/state/ViewerState.java
@@ -487,4 +487,18 @@ public class ViewerState
 	{
 		return numTimePoints;
 	}
+
+	/**
+	 * DON'T USE THIS.
+	 * <p>
+	 * This is a work around for JDK bug
+	 * https://bugs.openjdk.java.net/browse/JDK-8029147 which leads to
+	 * ViewerPanel not being garbage-collected when ViewerFrame is closed. So
+	 * instead we need to manually let go of resources...
+	 */
+	public void kill()
+	{
+		sources.clear();
+		groups.clear();
+	}
 }


### PR DESCRIPTION
…a memory leak. When a BDV ViewerFrame is closed it (and everything it references) is not garbage-collected. This "fix" at least nulls references to the big stuff...