### PR TITLE
raised VolatileImgCells cell index from int to long

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
+			<version>3.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>

--- a/src/main/java/bdv/img/cache/VolatileGlobalCellCache.java
+++ b/src/main/java/bdv/img/cache/VolatileGlobalCellCache.java
@@ -35,10 +35,10 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import bdv.img.cache.CacheIoTiming.IoStatistics;
 import bdv.img.cache.CacheIoTiming.IoTimeBudget;
 import bdv.img.cache.VolatileImgCells.CellCache;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 
 public class VolatileGlobalCellCache implements Cache
 {
@@ -56,9 +56,9 @@ public class VolatileGlobalCellCache implements Cache
 
 		private final int level;
 
-		private final int index;
+		private final long index;
 
-		public Key( final int timepoint, final int setup, final int level, final int index )
+		public Key( final int timepoint, final int setup, final int level, final long index )
 		{
 			this.timepoint = timepoint;
 			this.setup = setup;
@@ -441,7 +441,12 @@ public class VolatileGlobalCellCache implements Cache
 	 *            {@link LoadingStrategy}, queue priority, and queue order.
 	 * @return a cell with the specified coordinates or null.
 	 */
-	public VolatileCell< ? > getGlobalIfCached( final int timepoint, final int setup, final int level, final int index, final CacheHints cacheHints )
+	public VolatileCell< ? > getGlobalIfCached(
+			final int timepoint,
+			final int setup,
+			final int level,
+			final long index,
+			final CacheHints cacheHints )
 	{
 		final Key k = new Key( timepoint, setup, level, index );
 		final Reference< Entry< ? > > ref = softReferenceCache.get( k );
@@ -512,7 +517,15 @@ public class VolatileGlobalCellCache implements Cache
 	 *            {@link LoadingStrategy}, queue priority, and queue order.
 	 * @return a cell with the specified coordinates.
 	 */
-	public < A extends VolatileAccess > VolatileCell< ? > createGlobal( final int[] cellDims, final long[] cellMin, final int timepoint, final int setup, final int level, final int index, final CacheHints cacheHints, final CacheArrayLoader< A > loader )
+	public < A extends VolatileAccess > VolatileCell< ? > createGlobal(
+			final int[] cellDims,
+			final long[] cellMin,
+			final int timepoint,
+			final int setup,
+			final int level,
+			final long index,
+			final CacheHints cacheHints,
+			final CacheArrayLoader< A > loader )
 	{
 		final Key k = new Key( timepoint, setup, level, index );
 		Entry< ? > entry = null;
@@ -641,14 +654,14 @@ public class VolatileGlobalCellCache implements Cache
 
 		@SuppressWarnings( "unchecked" )
 		@Override
-		public VolatileCell< A > get( final int index )
+		public VolatileCell< A > get( final long index )
 		{
 			return ( VolatileCell< A > ) getGlobalIfCached( timepoint, setup, level, index, cacheHints );
 		}
 
 		@SuppressWarnings( "unchecked" )
 		@Override
-		public VolatileCell< A > load( final int index, final int[] cellDims, final long[] cellMin )
+		public VolatileCell< A > load( final long index, final int[] cellDims, final long[] cellMin )
 		{
 			return ( VolatileCell< A > ) createGlobal( cellDims, cellMin, timepoint, setup, level, index, cacheHints, loader );
 		}

--- a/src/main/java/bdv/img/cache/VolatileImgCells.java
+++ b/src/main/java/bdv/img/cache/VolatileImgCells.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,10 +28,15 @@
  */
 package bdv.img.cache;
 
-import net.imglib2.img.Img;
+import net.imglib2.AbstractLocalizable;
+import net.imglib2.Cursor;
+import net.imglib2.FlatIterationOrder;
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.AbstractImg;
+import net.imglib2.img.ImgFactory;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.cell.AbstractCells;
-import net.imglib2.img.list.AbstractListImg;
 import net.imglib2.util.Fraction;
 import net.imglib2.util.IntervalIndexer;
 
@@ -44,7 +49,7 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 		 *
 		 * @return cell at index or null if the cell is not in the cache.
 		 */
-		public VolatileCell< A > get( final int index );
+		public VolatileCell< A > get( final long index );
 
 		/**
 		 * Load a cell into memory (eventually) and put it into the cache at the
@@ -60,7 +65,7 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 		 *            offset of the cell in image coordinates.
 		 * @return cell at index
 		 */
-		public VolatileCell< A > load( final int index, final int[] cellDims, final long[] cellMin );
+		public VolatileCell< A > load( final long index, final int[] cellDims, final long[] cellMin );
 
 		/**
 		 * Set {@link CacheHints hints} on how to handle cell requests for this
@@ -89,15 +94,159 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 		return cells;
 	}
 
-	public class CachedCells extends AbstractListImg< VolatileCell< A > >
+	public class CachedCells extends AbstractImg< VolatileCell< A > >
 	{
+		public class CachedCellsRandomAccess extends AbstractLocalizable implements RandomAccess< VolatileCell< A > >
+		{
+			private long i;
+
+			public CachedCellsRandomAccess()
+			{
+				super( CachedCells.this.numDimensions() );
+			}
+
+			public CachedCellsRandomAccess( final CachedCellsRandomAccess randomAccess )
+			{
+				super( randomAccess.numDimensions() );
+
+				for ( int d = 0; d < n; ++d )
+					position[ d ] = randomAccess.position[ d ];
+
+				i = randomAccess.i;
+			}
+
+			@Override
+			public VolatileCell< A > get()
+			{
+				return CachedCells.this.get( i );
+			}
+
+			public void set( final VolatileCell< A > t )
+			{
+				CachedCells.this.set( i, t );
+			}
+
+			@Override
+			public void fwd( final int d )
+			{
+				i += step[ d ];
+				++position[ d ];
+			}
+
+			@Override
+			public void bck( final int d )
+			{
+				i -= step[ d ];
+				--position[ d ];
+			}
+
+			@Override
+			public void move( final int distance, final int d )
+			{
+				i += step[ d ] * distance;
+				position[ d ] += distance;
+			}
+
+			@Override
+			public void move( final long distance, final int d )
+			{
+				move( distance, d );
+			}
+
+			@Override
+			public void move( final Localizable localizable )
+			{
+				for ( int d = 0; d < n; ++d )
+					move( localizable.getLongPosition( d ), d );
+			}
+
+			@Override
+			public void move( final int[] distance )
+			{
+				for ( int d = 0; d < n; ++d )
+					move( distance[ d ], d );
+			}
+
+			@Override
+			public void move( final long[] distance )
+			{
+				for ( int d = 0; d < n; ++d )
+					move( distance[ d ], d );
+			}
+
+			@Override
+			public void setPosition( final Localizable localizable )
+			{
+				localizable.localize( position );
+				i = position[ 0 ];
+				for ( int d = 1; d < n; ++d )
+					i += position[ d ] * step[ d ];
+			}
+
+			@Override
+			public void setPosition( final int[] position )
+			{
+				i = position[ 0 ];
+				this.position[ 0 ] = i;
+				for ( int d = 1; d < n; ++d )
+				{
+					final long p = position[ d ];
+					i += p * step[ d ];
+					this.position[ d ] = p;
+				}
+			}
+
+			@Override
+			public void setPosition( final long[] position )
+			{
+				i = position[ 0 ];
+				this.position[ 0 ] = i;
+				for ( int d = 1; d < n; ++d )
+				{
+					final long p = position[ d ];
+					i += p * step[ d ];
+					this.position[ d ] = p;
+				}
+			}
+
+			@Override
+			public void setPosition( final int position, final int d )
+			{
+				i += step[ d ] * ( position - this.position[ d ] );
+				this.position[ d ] = position;
+			}
+
+			@Override
+			public void setPosition( final long position, final int d )
+			{
+				i += step[ d ] * ( position - this.position[ d ] );
+				this.position[ d ] = position;
+			}
+
+			@Override
+			public CachedCellsRandomAccess copy()
+			{
+				return new CachedCellsRandomAccess( this );
+			}
+
+			@Override
+			public CachedCellsRandomAccess copyRandomAccess()
+			{
+				return copy();
+			}
+		}
+
+		final protected long[] step;
+
 		protected CachedCells( final long[] dim )
 		{
 			super( dim );
+
+			step = new long[ n ];
+			IntervalIndexer.createAllocationSteps( dimension, step );
 		}
 
-		@Override
-		protected VolatileCell< A > get( final int index )
+		protected VolatileCell< A > get( final long index )
 		{
 			final VolatileCell< A > cell = cache.get( index );
 			if ( cell != null )
@@ -105,19 +254,48 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 			final long[] cellGridPosition = new long[ n ];
 			final long[] cellMin = new long[ n ];
 			final int[] cellDims  = new int[ n ];
-			IntervalIndexer.indexToPosition( index, dim, cellGridPosition );
+			IntervalIndexer.indexToPosition( index, dimension, cellGridPosition );
 			getCellDimensions( cellGridPosition, cellMin, cellDims );
 			return cache.load( index, cellDims, cellMin );
 		}
 
 		@Override
-		public Img< VolatileCell< A > > copy()
+		public CachedCellsRandomAccess randomAccess()
+		{
+			return new CachedCellsRandomAccess();
+		}
+
+		@Override
+		public FlatIterationOrder iterationOrder()
+		{
+			return new FlatIterationOrder( this );
+		}
+
+		@Override
+		public CachedCells copy()
+		{
+			return new CachedCells( dimensions );
+		}
+
+		protected void set( final long index, final VolatileCell< A > value )
 		{
 			throw new UnsupportedOperationException( "Not supported" );
 		}
 
 		@Override
-		protected void set( final int index, final VolatileCell< A > value )
+		public ImgFactory< VolatileCell< A > > factory()
+		{
+			throw new UnsupportedOperationException( "Not supported" );
+		}
+
+		@Override
+		public Cursor< VolatileCell< A > > cursor()
+		{
+			throw new UnsupportedOperationException( "Not supported" );
+		}
+
+		@Override
+		public Cursor< VolatileCell< A > > localizingCursor()
 		{
 			throw new UnsupportedOperationException( "Not supported" );
 		}

--- a/src/main/java/bdv/img/cache/VolatileImgCells.java
+++ b/src/main/java/bdv/img/cache/VolatileImgCells.java
@@ -28,15 +28,11 @@
  */
 package bdv.img.cache;
 
-import net.imglib2.AbstractLocalizable;
-import net.imglib2.Cursor;
-import net.imglib2.FlatIterationOrder;
-import net.imglib2.Localizable;
-import net.imglib2.RandomAccess;
-import net.imglib2.img.AbstractImg;
+import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.cell.AbstractCells;
+import net.imglib2.img.list.AbstractLongListImg;
 import net.imglib2.util.Fraction;
 import net.imglib2.util.IntervalIndexer;
 
@@ -94,158 +90,14 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 		return cells;
 	}
 
-	public class CachedCells extends AbstractImg< VolatileCell< A > >
+	public class CachedCells extends AbstractLongListImg< VolatileCell< A > >
 	{
-		public class CachedCellsRandomAccess extends AbstractLocalizable implements RandomAccess< VolatileCell< A > >
-		{
-			private long i;
-
-			public CachedCellsRandomAccess()
-			{
-				super( CachedCells.this.numDimensions() );
-			}
-
-			public CachedCellsRandomAccess( final CachedCellsRandomAccess randomAccess )
-			{
-				super( randomAccess.numDimensions() );
-
-				for ( int d = 0; d < n; ++d )
-					position[ d ] = randomAccess.position[ d ];
-
-				i = randomAccess.i;
-			}
-
-			@Override
-			public VolatileCell< A > get()
-			{
-				return CachedCells.this.get( i );
-			}
-
-			public void set( final VolatileCell< A > t )
-			{
-				CachedCells.this.set( i, t );
-			}
-
-			@Override
-			public void fwd( final int d )
-			{
-				i += step[ d ];
-				++position[ d ];
-			}
-
-			@Override
-			public void bck( final int d )
-			{
-				i -= step[ d ];
-				--position[ d ];
-			}
-
-			@Override
-			public void move( final int distance, final int d )
-			{
-				i += step[ d ] * distance;
-				position[ d ] += distance;
-			}
-
-			@Override
-			public void move( final long distance, final int d )
-			{
-				move( distance, d );
-			}
-
-			@Override
-			public void move( final Localizable localizable )
-			{
-				for ( int d = 0; d < n; ++d )
-					move( localizable.getLongPosition( d ), d );
-			}
-
-			@Override
-			public void move( final int[] distance )
-			{
-				for ( int d = 0; d < n; ++d )
-					move( distance[ d ], d );
-			}
-
-			@Override
-			public void move( final long[] distance )
-			{
-				for ( int d = 0; d < n; ++d )
-					move( distance[ d ], d );
-			}
-
-			@Override
-			public void setPosition( final Localizable localizable )
-			{
-				localizable.localize( position );
-				i = position[ 0 ];
-				for ( int d = 1; d < n; ++d )
-					i += position[ d ] * step[ d ];
-			}
-
-			@Override
-			public void setPosition( final int[] position )
-			{
-				i = position[ 0 ];
-				this.position[ 0 ] = i;
-				for ( int d = 1; d < n; ++d )
-				{
-					final long p = position[ d ];
-					i += p * step[ d ];
-					this.position[ d ] = p;
-				}
-			}
-
-			@Override
-			public void setPosition( final long[] position )
-			{
-				i = position[ 0 ];
-				this.position[ 0 ] = i;
-				for ( int d = 1; d < n; ++d )
-				{
-					final long p = position[ d ];
-					i += p * step[ d ];
-					this.position[ d ] = p;
-				}
-			}
-
-			@Override
-			public void setPosition( final int position, final int d )
-			{
-				i += step[ d ] * ( position - this.position[ d ] );
-				this.position[ d ] = position;
-			}
-
-			@Override
-			public void setPosition( final long position, final int d )
-			{
-				i += step[ d ] * ( position - this.position[ d ] );
-				this.position[ d ] = position;
-			}
-
-			@Override
-			public CachedCellsRandomAccess copy()
-			{
-				return new CachedCellsRandomAccess( this );
-			}
-
-			@Override
-			public CachedCellsRandomAccess copyRandomAccess()
-			{
-				return copy();
-			}
-		}
-
-		final protected long[] step;
-
 		protected CachedCells( final long[] dim )
 		{
 			super( dim );
-
-			step = new long[ n ];
-			IntervalIndexer.createAllocationSteps( dimension, step );
 		}
 
+		@Override
 		protected VolatileCell< A > get( final long index )
 		{
 			final VolatileCell< A > cell = cache.get( index );
@@ -260,23 +112,12 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 		}
 
 		@Override
-		public CachedCellsRandomAccess randomAccess()
+		public Img< VolatileCell< A > > copy()
 		{
-			return new CachedCellsRandomAccess();
+			throw new UnsupportedOperationException( "Not supported" );
 		}
 
 		@Override
-		public FlatIterationOrder iterationOrder()
-		{
-			return new FlatIterationOrder( this );
-		}
-
-		@Override
-		public CachedCells copy()
-		{
-			return new CachedCells( dimensions );
-		}
-
 		protected void set( final long index, final VolatileCell< A > value )
 		{
 			throw new UnsupportedOperationException( "Not supported" );
@@ -284,18 +125,6 @@ public class VolatileImgCells< A extends VolatileAccess > extends AbstractCells<
 
 		@Override
 		public ImgFactory< VolatileCell< A > > factory()
-		{
-			throw new UnsupportedOperationException( "Not supported" );
-		}
-
-		@Override
-		public Cursor< VolatileCell< A > > cursor()
-		{
-			throw new UnsupportedOperationException( "Not supported" );
-		}
-
-		@Override
-		public Cursor< VolatileCell< A > > localizingCursor()
 		{
 			throw new UnsupportedOperationException( "Not supported" );
 		}


### PR DESCRIPTION
This enables to index cache cells for larger images.  My story was this: showing a volume of 200,000x150,000x8,000px in blocks of 64x64x1px blocks failed because it had to be able to index more than 27&times; too many cache cells.  It also did not fail in a user friendly way but generated overflows into negative cell-coordinates---pretty ugly.  I am not sure how much that breaks outside of core and my own projects because I also had to move away from `ListImg`, @tpietzsch?