### PR TITLE
Avoid exception when canvas size is zero

### DIFF
--- a/src/main/java/bdv/BehaviourTransformEventHandler3D.java
+++ b/src/main/java/bdv/BehaviourTransformEventHandler3D.java
@@ -184,6 +184,12 @@ public class BehaviourTransformEventHandler3D implements BehaviourTransformEvent
 	@Override
 	public void setCanvasSize( final int width, final int height, final boolean updateTransform )
 	{
+		if ( width == 0 || height == 0 ) {
+			// NB: We are probably in some intermediate layout scenario.
+			// Attempting to trigger a transform update with 0 size will result
+			// in the exception "Matrix is singular" from imglib2-realtrasform.
+			return;
+		}
 		if ( updateTransform )
 		{
 			synchronized ( affine )


### PR DESCRIPTION
I ran into a case where `BehaviourTransformEventHandler3D.setCanvasSize` gets called with (0, 0) size. When this occurs, we should perform a new transformation because it will result in a "Matrix is singular" exception. In practice, this call happens at an intermediate layout step, after which the canvas will be resized again to non-zero size.