### PR TITLE
Change BrightnessDialog checkbox behavior

### DIFF
--- a/src/main/java/bdv/tools/brightness/BrightnessDialog.java
+++ b/src/main/java/bdv/tools/brightness/BrightnessDialog.java
@@ -382,8 +382,8 @@ public class BrightnessDialog extends JDialog
 					{
 						if ( box.isSelected() )
 							assignments.moveSetupToGroup( setup, minMaxGroup );
-						else
-							assignments.removeSetupFromGroup( setup, minMaxGroup );
+						else if ( !assignments.removeSetupFromGroup( setup, minMaxGroup ) )
+							box.setSelected( true );
 					}
 				} );
 				boxesPanel.add( box );

--- a/src/main/java/bdv/tools/brightness/SetupAssignments.java
+++ b/src/main/java/bdv/tools/brightness/SetupAssignments.java
@@ -145,16 +145,21 @@ public class SetupAssignments
 	}
 
 	/**
-	 * Remove the specified setup from the specified group. If this group is
-	 * made empty by this, it is removed from the list of groups. A new group is
-	 * created containing only the specified setup, and this new group is added
-	 * to the list of group. The settings of the new group are initialized with
-	 * the settings of the old group.
+	 * Remove the specified setup from the specified group. If this group would
+	 * be made empty by this, it is not removed from the group. Otherwise, after
+	 * being removed, a new group is created containing only the specified
+	 * setup, and this new group is added to the list of group. The settings of
+	 * the new group are initialized with the settings of the old group.
+	 * 
+	 * @return Whether or not removal was successful (so the corresponding
+	 *         checkbox can be re-checked)
 	 */
-	public void removeSetupFromGroup( final ConverterSetup setup, final MinMaxGroup group )
+	public boolean removeSetupFromGroup( final ConverterSetup setup, final MinMaxGroup group )
 	{
 		if ( setupToGroup.get( setup ) != group )
-			return;
+			return false;
+		if ( group.setups.size() == 1 )
+			return false;
 
 		final MinMaxGroup newGroup = new MinMaxGroup( group.getFullRangeMin(), group.getFullRangeMax(), group.getRangeMin(), group.getRangeMax(), setup.getDisplayRangeMin(), setup.getDisplayRangeMax(), minIntervalSize );
 		minMaxGroups.add( newGroup );
@@ -167,6 +172,7 @@ public class SetupAssignments
 
 		if ( updateListener != null )
 			updateListener.update();
+		return true;
 	}
 
 	public void setUpdateListener( final UpdateListener l )


### PR DESCRIPTION
When a checkbox is unchecked and removes a minmax setup from a group that only has the one setup left, rather than remove and re-add it to the bottom, it now stays where it is.

The old behavior was somewhat confusing and has no apparent usefulness, other than reordering the minmax groups.

Old Behavior:
![](https://i.imgur.com/dWexnHK.gif)

New Behavior:
![](https://i.imgur.com/8VtdFSO.gif)


