### PR TITLE
Set interpolation directly

### DIFF
--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -636,14 +636,22 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, TransformLis
 		final Interpolation interpolation = state.getInterpolation();
 		if ( interpolation == Interpolation.NEARESTNEIGHBOR )
 		{
-			state.setInterpolation( Interpolation.NLINEAR );
 			showMessage( "tri-linear interpolation" );
+			setInterpolation( Interpolation.NLINEAR );
 		}
 		else
 		{
-			state.setInterpolation( Interpolation.NEARESTNEIGHBOR );
 			showMessage( "nearest-neighbor interpolation" );
+			setInterpolation( Interpolation.NEARESTNEIGHBOR );
 		}
+	}
+
+	/**
+	 * Set interpolation to specified method.
+	 */
+	public synchronized void setInterpolation( final Interpolation method )
+	{
+		state.setInterpolation( method );
 		requestRepaint();
 	}
 


### PR DESCRIPTION
Before only toggling interpolation was possible.

In my use case I have a state handler object that handles the shared state of multiple viewers. In order to change the interpolation method consistently, I need to be able to set the interpolation method directly instead of toggling/cycling through the interpolation method values.