### PR TITLE
Expose renderTarget

### DIFF
--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -1123,4 +1123,10 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, TransformLis
 			return t;
 		}
 	}
+
+	public TransformAwareBufferedImageOverlayRenderer renderTarget()
+	{
+		return this.renderTarget;
+	}
+
 }


### PR DESCRIPTION
I have ortho slices in a 3D viewer window that reflect the contents of three (orthogonal) `ViewerPanel`s. These ortho slices show textures that are generated whenever the `renderTarget` notifies its listeners that are added through `ViewerPanel.addRenderTransformListener`. In order to render the image onto the ortho slice, I need to have access to `renderTarget`.