### PR TITLE
HDF5 native types support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 # IntelliJ
 .idea/
 *.iml
+
+# VIM
+.*.swp

--- a/src/main/java/bdv/export/HDF5Access.java
+++ b/src/main/java/bdv/export/HDF5Access.java
@@ -67,8 +67,7 @@ class HDF5Access implements IHDF5Access
 	}
 
 	@Override
-	//TODO VLADO: data should be of type Object
-	public void writeBlockWithOffset( final short[] data, final long[] blockDimensions, final long[] offset )
+	public void writeBlockWithOffset( final Object data, final long[] blockDimensions, final long[] offset )
 	{
 		reorder( blockDimensions, reorderedDimensions );
 		reorder( offset, reorderedOffset );

--- a/src/main/java/bdv/export/HDF5Access.java
+++ b/src/main/java/bdv/export/HDF5Access.java
@@ -30,14 +30,15 @@
 package bdv.export;
 
 import static bdv.img.hdf5.Util.reorder;
+import static bdv.export.Hdf5BlockWriterPixelTypes.PixelTypeMaintainer;
 import bdv.img.hdf5.Util;
-import ch.systemsx.cisd.base.mdarray.MDShortArray;
 import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
 
 class HDF5Access implements IHDF5Access
 {
 	private final IHDF5Writer hdf5Writer;
+	private final PixelTypeMaintainer px;
 
 	private final long[] reorderedDimensions = new long[ 3 ];
 
@@ -45,9 +46,10 @@ class HDF5Access implements IHDF5Access
 
 	private String datasetPath;
 
-	public HDF5Access( final IHDF5Writer hdf5Writer )
+	public HDF5Access( final IHDF5Writer hdf5Writer, final PixelTypeMaintainer px )
 	{
 		this.hdf5Writer = hdf5Writer;
+		this.px = px;
 	}
 
 	@Override
@@ -60,17 +62,17 @@ class HDF5Access implements IHDF5Access
 	@Override
 	public void createAndOpenDataset( final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features )
 	{
-		hdf5Writer.int16().createMDArray( path, reorder( dimensions ), reorder( cellDimensions ), features );
+		px.createAndOpenDataset( hdf5Writer, path, reorder( dimensions ), reorder( cellDimensions ), features );
 		this.datasetPath = path;
 	}
 
 	@Override
+	//TODO VLADO: data should be of type Object
 	public void writeBlockWithOffset( final short[] data, final long[] blockDimensions, final long[] offset )
 	{
 		reorder( blockDimensions, reorderedDimensions );
 		reorder( offset, reorderedOffset );
-		final MDShortArray array = new MDShortArray( data, reorderedDimensions );
-		hdf5Writer.int16().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		px.hdf5writer( hdf5Writer, data, reorderedDimensions, datasetPath, reorderedOffset );
 	}
 
 	@Override

--- a/src/main/java/bdv/export/HDF5Access.java
+++ b/src/main/java/bdv/export/HDF5Access.java
@@ -38,7 +38,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Writer;
 class HDF5Access implements IHDF5Access
 {
 	private final IHDF5Writer hdf5Writer;
-	private final PixelTypeMaintainer px;
+	private final PixelTypeMaintainer<?> px;
 
 	private final long[] reorderedDimensions = new long[ 3 ];
 
@@ -46,7 +46,7 @@ class HDF5Access implements IHDF5Access
 
 	private String datasetPath;
 
-	public HDF5Access( final IHDF5Writer hdf5Writer, final PixelTypeMaintainer px )
+	public HDF5Access( final IHDF5Writer hdf5Writer, final PixelTypeMaintainer<?> px )
 	{
 		this.hdf5Writer = hdf5Writer;
 		this.px = px;

--- a/src/main/java/bdv/export/HDF5AccessHack.java
+++ b/src/main/java/bdv/export/HDF5AccessHack.java
@@ -95,7 +95,7 @@ class HDF5AccessHack implements IHDF5Access
 	@Override
 	public void createAndOpenDataset( final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features )
 	{
-		hdf5Writer.int16().createMDArray( path, reorder( dimensions ), reorder( cellDimensions ), features );
+		px.createAndOpenDataset( hdf5Writer, path, reorder( dimensions ), reorder( cellDimensions ), features );
 		dataSetId = H5Dopen( fileId, path, H5P_DEFAULT );
 		fileSpaceId = H5Dget_space( dataSetId );
 	}

--- a/src/main/java/bdv/export/HDF5AccessHack.java
+++ b/src/main/java/bdv/export/HDF5AccessHack.java
@@ -49,7 +49,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Writer;
 class HDF5AccessHack implements IHDF5Access
 {
 	private final IHDF5Writer hdf5Writer;
-	private final PixelTypeMaintainer px;
+	private final PixelTypeMaintainer<?> px;
 
 	private final long[] reorderedDimensions = new long[ 3 ];
 
@@ -61,7 +61,7 @@ class HDF5AccessHack implements IHDF5Access
 
 	private int fileSpaceId;
 
-	public HDF5AccessHack(final IHDF5Writer hdf5Writer, final PixelTypeMaintainer px )
+	public HDF5AccessHack(final IHDF5Writer hdf5Writer, final PixelTypeMaintainer<?> px )
 	throws ClassNotFoundException, SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException
 	{
 		this.hdf5Writer = hdf5Writer;

--- a/src/main/java/bdv/export/HDF5AccessHack.java
+++ b/src/main/java/bdv/export/HDF5AccessHack.java
@@ -101,8 +101,7 @@ class HDF5AccessHack implements IHDF5Access
 	}
 
 	@Override
-	//TODO VLADO: data should be of type Object
-	public void writeBlockWithOffset( final short[] data, final long[] blockDimensions, final long[] offset )
+	public void writeBlockWithOffset( final Object data, final long[] blockDimensions, final long[] offset )
 	{
 		reorder( blockDimensions, reorderedDimensions );
 		reorder( offset, reorderedOffset );

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -94,6 +94,8 @@ public class Hdf5BlockWriterPixelTypes
 {
 	public interface PixelTypeMaintainer
 	{
+		String reportPixelType();
+
 		// ---------- writing ----------
 		///for the export/HDF5AccessHack
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data);
@@ -166,6 +168,11 @@ public class Hdf5BlockWriterPixelTypes
 	static
 	class ByteTypeMaintainer implements PixelTypeMaintainer
 	{
+		@Override
+		public
+		String reportPixelType()
+		{ return new String("ByteType"); }
+
 		@Override
 		public
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
@@ -259,6 +266,11 @@ public class Hdf5BlockWriterPixelTypes
 	static
 	class UnsignedByteTypeMaintainer implements PixelTypeMaintainer
 	{
+		@Override
+		public
+		String reportPixelType()
+		{ return new String("UnsignedByteType"); }
+
 		@Override
 		public
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
@@ -357,6 +369,11 @@ public class Hdf5BlockWriterPixelTypes
 	{
 		@Override
 		public
+		String reportPixelType()
+		{ return new String("ShortType"); }
+
+		@Override
+		public
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
 		{
 			return H5Dwrite(dataset_id, H5T_NATIVE_INT16, mem_space_id, file_space_id, H5P_DEFAULT, (short[])data);
@@ -448,6 +465,11 @@ public class Hdf5BlockWriterPixelTypes
 	static
 	class UnsignedShortTypeMaintainer implements PixelTypeMaintainer
 	{
+		@Override
+		public
+		String reportPixelType()
+		{ return new String("UnsignedShortType"); }
+
 		@Override
 		public
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
@@ -544,6 +566,11 @@ public class Hdf5BlockWriterPixelTypes
 	static
 	class FloatTypeMaintainer implements PixelTypeMaintainer
 	{
+		@Override
+		public
+		String reportPixelType()
+		{ return new String("FloatType"); }
+
 		@Override
 		public
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -57,7 +57,6 @@ import ch.systemsx.cisd.base.mdarray.MDFloatArray;
 //for the WriteSequenceToHdf5
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
-
 //to create the right object
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -112,6 +111,11 @@ public class Hdf5BlockWriterPixelTypes
 
 		///for the Hdf5ImageLoader.open()
 		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access);
+
+		///for the Hdf5ImageLoader.loadImageCompletely()
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException;
+		ArrayImg<?,?> createArrayImg(final Object data, final long[] dims);
 
 		///for methods inside the class Hdf5VolatileTypeArrayLoader
 		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
@@ -190,12 +194,18 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return ArrayImgs.bytes(dims);
 		}
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final Object data, final long[] dims)
+		{
+			return ArrayImgs.bytes((byte[])data, dims);
+		}
 
 		@Override
 		public
 		SetupImgLoader<?,?> createSetupImgLoader(final Hdf5ImageLoader loader, final int setupId, final MipmapInfo mipmapInfo)
 		{
-			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new ByteType(), new VolatileByteType());
+			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new ByteType(), new VolatileByteType(), this);
 		}
 
 		@Override
@@ -203,6 +213,19 @@ public class Hdf5BlockWriterPixelTypes
 		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
 		{
 			return new Hdf5VolatileTypeArrayLoader<VolatileByteArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+		{
+			return hdf5Access.readByteMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+		}
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException
+		{
+			return hdf5Access.readByteMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, (byte[])dataBlock );
 		}
 
 		@Override
@@ -264,12 +287,18 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return ArrayImgs.unsignedBytes(dims);
 		}
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final Object data, final long[] dims)
+		{
+			return ArrayImgs.unsignedBytes((byte[])data, dims);
+		}
 
 		@Override
 		public
 		SetupImgLoader<?,?> createSetupImgLoader(final Hdf5ImageLoader loader, final int setupId, final MipmapInfo mipmapInfo)
 		{
-			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new UnsignedByteType(), new VolatileUnsignedByteType());
+			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new UnsignedByteType(), new VolatileUnsignedByteType(), this);
 		}
 
 		@Override
@@ -278,6 +307,19 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			//TODO UNSIGNED
 			return new Hdf5VolatileTypeArrayLoader<VolatileByteArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+		{
+			return hdf5Access.readByteMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+		}
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException
+		{
+			return hdf5Access.readByteMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, (byte[])dataBlock );
 		}
 
 		@Override
@@ -341,12 +383,18 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return ArrayImgs.shorts(dims);
 		}
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final Object data, final long[] dims)
+		{
+			return ArrayImgs.shorts((short[])data, dims);
+		}
 
 		@Override
 		public
 		SetupImgLoader<?,?> createSetupImgLoader(final Hdf5ImageLoader loader, final int setupId, final MipmapInfo mipmapInfo)
 		{
-			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new ShortType(), new VolatileShortType());
+			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new ShortType(), new VolatileShortType(), this);
 		}
 
 		@Override
@@ -354,6 +402,19 @@ public class Hdf5BlockWriterPixelTypes
 		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
 		{
 			return new Hdf5VolatileTypeArrayLoader<VolatileShortArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+		{
+			return hdf5Access.readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+		}
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException
+		{
+			return hdf5Access.readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, (short[])dataBlock );
 		}
 
 		@Override
@@ -415,12 +476,18 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return ArrayImgs.unsignedShorts(dims);
 		}
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final Object data, final long[] dims)
+		{
+			return ArrayImgs.unsignedShorts((short[])data, dims);
+		}
 
 		@Override
 		public
 		SetupImgLoader<?,?> createSetupImgLoader(final Hdf5ImageLoader loader, final int setupId, final MipmapInfo mipmapInfo)
 		{
-			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new UnsignedShortType(), new VolatileUnsignedShortType());
+			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new UnsignedShortType(), new VolatileUnsignedShortType(), this);
 		}
 
 		@Override
@@ -429,6 +496,19 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			//TODO UNSIGNED
 			return new Hdf5VolatileTypeArrayLoader<VolatileShortArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+		{
+			return hdf5Access.readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+		}
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException
+		{
+			return hdf5Access.readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, (short[])dataBlock );
 		}
 
 		@Override
@@ -495,12 +575,18 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return ArrayImgs.floats(dims);
 		}
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final Object data, final long[] dims)
+		{
+			return ArrayImgs.floats((float[])data, dims);
+		}
 
 		@Override
 		public
 		SetupImgLoader<?,?> createSetupImgLoader(final Hdf5ImageLoader loader, final int setupId, final MipmapInfo mipmapInfo)
 		{
-			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new FloatType(), new VolatileFloatType());
+			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new FloatType(), new VolatileFloatType(), this);
 		}
 
 		@Override
@@ -508,6 +594,19 @@ public class Hdf5BlockWriterPixelTypes
 		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
 		{
 			return new Hdf5VolatileTypeArrayLoader<VolatileFloatArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+		{
+			return hdf5Access.readFloatMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+		}
+		@Override
+		public
+		Object readSpecificMDArrayBlockWithOffset(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException
+		{
+			return hdf5Access.readFloatMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, (float[])dataBlock );
 		}
 
 		@Override

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -70,9 +70,20 @@ import net.imglib2.type.volatiles.VolatileShortType;
 import net.imglib2.type.volatiles.VolatileUnsignedShortType;
 import net.imglib2.type.volatiles.VolatileFloatType;
 
+//for Hdf5VolatileTypeArrayLoader's methods
+import bdv.img.cache.CacheArrayLoader;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileArrayDataAccess;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileByteArray;
+//import net.imglib2.img.basictypeaccess.volatiles.array.VolatileUnsignedByteArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileShortArray;
+//import net.imglib2.img.basictypeaccess.volatiles.array.VolatileUnsignedShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileFloatArray;
+import bdv.img.hdf5.IHDF5Access;
+
 //to create the SetupImgLoader
 import bdv.img.hdf5.Hdf5ImageLoader;
 import bdv.img.hdf5.Hdf5ImageLoader.SetupImgLoader;
+import bdv.img.hdf5.Hdf5VolatileTypeArrayLoader;
 import bdv.img.hdf5.MipmapInfo;
 
 public class Hdf5BlockWriterPixelTypes
@@ -91,8 +102,15 @@ public class Hdf5BlockWriterPixelTypes
 		ArrayImg<?,?> createArrayImg(final long[] dims);
 
 		// ---------- reading ----------
-		///for the Hdf5ImageLoader; instantiate always in appropriate pairs, e.g., UnsignedShortType and VolatileUnsignedShortType
+		///for the Hdf5ImageLoader.open(); instantiate always in appropriate pairs, e.g., UnsignedShortType and VolatileUnsignedShortType
 		SetupImgLoader<?,?> createSetupImgLoader(final Hdf5ImageLoader loader, final int setupId, final MipmapInfo mipmapInfo);
+
+		///for the Hdf5ImageLoader.open()
+		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access);
+
+		///for methods inside the class Hdf5VolatileTypeArrayLoader
+		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+		int getBytesPerElement();
 	}
 
 	/**
@@ -168,6 +186,26 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new ByteType(), new VolatileByteType());
 		}
+
+		@Override
+		public
+		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
+		{
+			return new Hdf5VolatileTypeArrayLoader<VolatileByteArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min )
+		throws InterruptedException
+		{
+			final byte[] array = hdf5Access.readByteMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+			return new VolatileByteArray( array, true );
+		}
+
+		@Override
+		public
+		int getBytesPerElement() { return 1; }
 	}
 
 	static
@@ -208,6 +246,28 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new UnsignedByteType(), new VolatileUnsignedByteType());
 		}
+
+		@Override
+		public
+		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
+		{
+			//TODO UNSIGNED
+			return new Hdf5VolatileTypeArrayLoader<VolatileByteArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min )
+		throws InterruptedException
+		{
+			//TODO UNSIGNED
+			final byte[] array = hdf5Access.readByteMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+			return new VolatileByteArray( array, true );
+		}
+
+		@Override
+		public
+		int getBytesPerElement() { return 1; }
 	}
 
 	// ------------------------------------------------------
@@ -249,6 +309,26 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new ShortType(), new VolatileShortType());
 		}
+
+		@Override
+		public
+		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
+		{
+			return new Hdf5VolatileTypeArrayLoader<VolatileShortArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min )
+		throws InterruptedException
+		{
+			final short[] array = hdf5Access.readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+			return new VolatileShortArray( array, true );
+		}
+
+		@Override
+		public
+		int getBytesPerElement() { return 2; }
 	}
 
 	static
@@ -289,6 +369,28 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new UnsignedShortType(), new VolatileUnsignedShortType());
 		}
+
+		@Override
+		public
+		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
+		{
+			//TODO UNSIGNED
+			return new Hdf5VolatileTypeArrayLoader<VolatileShortArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min )
+		throws InterruptedException
+		{
+			//TODO UNSIGNED
+			final short[] array = hdf5Access.readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+			return new VolatileShortArray( array, true );
+		}
+
+		@Override
+		public
+		int getBytesPerElement() { return 2; }
 	}
 
 	// ------------------------------------------------------
@@ -333,6 +435,26 @@ public class Hdf5BlockWriterPixelTypes
 		{
 			return loader.new SetupImgLoader<>(setupId, mipmapInfo, new FloatType(), new VolatileFloatType());
 		}
+
+		@Override
+		public
+		CacheArrayLoader<?> createHdf5VolatileTypeArrayLoader(final IHDF5Access hdf5Access)
+		{
+			return new Hdf5VolatileTypeArrayLoader<VolatileFloatArray>( hdf5Access, this );
+		}
+
+		@Override
+		public
+		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min )
+		throws InterruptedException
+		{
+			final float[] array = hdf5Access.readFloatMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+			return new VolatileFloatArray( array, true );
+		}
+
+		@Override
+		public
+		int getBytesPerElement() { return 4; }
 	}
 
 	// ------------------------------------------------------

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -582,8 +582,7 @@ public class Hdf5BlockWriterPixelTypes
 		public
 		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features)
 		{
-			//final HDF5FloatStorageFeatures fFeatures = HDF5FloatStorageFeatures.FLOAT_NO_COMPRESSION;
-			//should translate the original HDF5IntStorageFeatures to HDF5FloatStorageFeatures, TODO VLADO confirm it preserves e.g. deflation option
+			//should translate the original HDF5IntStorageFeatures to HDF5FloatStorageFeatures
 			final HDF5FloatStorageFeatures fFeatures = HDF5FloatStorageFeatures.build(features).features();
 			hdf5Writer.float32().createMDArray( path, dimensions, cellDimensions, fFeatures );
 		}

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -97,7 +97,7 @@ public class Hdf5BlockWriterPixelTypes
 	public interface PixelTypeMaintainer<T extends RealType<T> & NativeType<T>>
 	{
 		String reportPixelType();
-		//TODO: createPixelType(); //TODO VLADO
+		//NB: one can create createPixelType(); if necessary
 
 		// ---------- writing ----------
 		///for the export/HDF5AccessHack

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -43,7 +43,7 @@ import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_UINT16;
 import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_FLOAT;
 //import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_DOUBLE;
 
-//for the HDF5Access
+//for the export/HDF5Access
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
 import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
 import ch.systemsx.cisd.hdf5.HDF5FloatStorageFeatures;
@@ -86,15 +86,20 @@ import bdv.img.hdf5.Hdf5ImageLoader.SetupImgLoader;
 import bdv.img.hdf5.Hdf5VolatileTypeArrayLoader;
 import bdv.img.hdf5.MipmapInfo;
 
+//for the img/hdf5/HDF5Access
+import ch.systemsx.cisd.base.mdarray.MDAbstractArray;
+import ch.systemsx.cisd.hdf5.IHDF5Reader;
+import static ch.systemsx.cisd.hdf5.hdf5lib.H5D.H5Dread;
+
 public class Hdf5BlockWriterPixelTypes
 {
 	public interface PixelTypeMaintainer
 	{
 		// ---------- writing ----------
-		///for the HDF5AccessHack
+		///for the export/HDF5AccessHack
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data);
 
-		///for the HDF5Access
+		///for the export/HDF5Access
 		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features);
 		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset);
 
@@ -111,6 +116,12 @@ public class Hdf5BlockWriterPixelTypes
 		///for methods inside the class Hdf5VolatileTypeArrayLoader
 		VolatileArrayDataAccess<?> loadArray(final IHDF5Access hdf5Access, final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
 		int getBytesPerElement();
+
+		///for the img/hdf5/HDF5Access
+		MDAbstractArray<?> readMDArrayBlockWithOffset( final IHDF5Reader hdf5Reader, final String path, final int[] reorderedDimensions, final long[] reorderedMin );
+
+		///for the img/hdf5/HDF5AccessHack
+		int h5Dread( final int dataSetId, final int memorySpaceId, final int fileSpaceId, final int numericConversionXferPropertyListID, final Object dataBlock );
 	}
 
 	/**
@@ -206,6 +217,20 @@ public class Hdf5BlockWriterPixelTypes
 		@Override
 		public
 		int getBytesPerElement() { return 1; }
+
+		@Override
+		public
+		MDAbstractArray<?> readMDArrayBlockWithOffset( final IHDF5Reader hdf5Reader, final String path, final int[] reorderedDimensions, final long[] reorderedMin )
+		{
+			return hdf5Reader.int8().readMDArrayBlockWithOffset( path, reorderedDimensions, reorderedMin );
+		}
+
+		@Override
+		public
+		int h5Dread( final int dataSetId, final int memorySpaceId, final int fileSpaceId, final int numericConversionXferPropertyListID, final Object dataBlock )
+		{
+			return H5Dread( dataSetId, H5T_NATIVE_INT8, memorySpaceId, fileSpaceId, numericConversionXferPropertyListID, (byte[])dataBlock );
+		}
 	}
 
 	static
@@ -268,6 +293,20 @@ public class Hdf5BlockWriterPixelTypes
 		@Override
 		public
 		int getBytesPerElement() { return 1; }
+
+		@Override
+		public
+		MDAbstractArray<?> readMDArrayBlockWithOffset( final IHDF5Reader hdf5Reader, final String path, final int[] reorderedDimensions, final long[] reorderedMin )
+		{
+			return hdf5Reader.int8().readMDArrayBlockWithOffset( path, reorderedDimensions, reorderedMin );
+		}
+
+		@Override
+		public
+		int h5Dread( final int dataSetId, final int memorySpaceId, final int fileSpaceId, final int numericConversionXferPropertyListID, final Object dataBlock )
+		{
+			return H5Dread( dataSetId, H5T_NATIVE_UINT8, memorySpaceId, fileSpaceId, numericConversionXferPropertyListID, (byte[])dataBlock );
+		}
 	}
 
 	// ------------------------------------------------------
@@ -329,6 +368,20 @@ public class Hdf5BlockWriterPixelTypes
 		@Override
 		public
 		int getBytesPerElement() { return 2; }
+
+		@Override
+		public
+		MDAbstractArray<?> readMDArrayBlockWithOffset( final IHDF5Reader hdf5Reader, final String path, final int[] reorderedDimensions, final long[] reorderedMin )
+		{
+			return hdf5Reader.int16().readMDArrayBlockWithOffset( path, reorderedDimensions, reorderedMin );
+		}
+
+		@Override
+		public
+		int h5Dread( final int dataSetId, final int memorySpaceId, final int fileSpaceId, final int numericConversionXferPropertyListID, final Object dataBlock )
+		{
+			return H5Dread( dataSetId, H5T_NATIVE_INT16, memorySpaceId, fileSpaceId, numericConversionXferPropertyListID, (short[])dataBlock );
+		}
 	}
 
 	static
@@ -391,6 +444,20 @@ public class Hdf5BlockWriterPixelTypes
 		@Override
 		public
 		int getBytesPerElement() { return 2; }
+
+		@Override
+		public
+		MDAbstractArray<?> readMDArrayBlockWithOffset( final IHDF5Reader hdf5Reader, final String path, final int[] reorderedDimensions, final long[] reorderedMin )
+		{
+			return hdf5Reader.int16().readMDArrayBlockWithOffset( path, reorderedDimensions, reorderedMin );
+		}
+
+		@Override
+		public
+		int h5Dread( final int dataSetId, final int memorySpaceId, final int fileSpaceId, final int numericConversionXferPropertyListID, final Object dataBlock )
+		{
+			return H5Dread( dataSetId, H5T_NATIVE_UINT16, memorySpaceId, fileSpaceId, numericConversionXferPropertyListID, (short[])dataBlock );
+		}
 	}
 
 	// ------------------------------------------------------
@@ -455,26 +522,19 @@ public class Hdf5BlockWriterPixelTypes
 		@Override
 		public
 		int getBytesPerElement() { return 4; }
+
+		@Override
+		public
+		MDAbstractArray<?> readMDArrayBlockWithOffset( final IHDF5Reader hdf5Reader, final String path, final int[] reorderedDimensions, final long[] reorderedMin )
+		{
+			return hdf5Reader.float32().readMDArrayBlockWithOffset( path, reorderedDimensions, reorderedMin );
+		}
+
+		@Override
+		public
+		int h5Dread( final int dataSetId, final int memorySpaceId, final int fileSpaceId, final int numericConversionXferPropertyListID, final Object dataBlock )
+		{
+			return H5Dread( dataSetId, H5T_NATIVE_FLOAT, memorySpaceId, fileSpaceId, numericConversionXferPropertyListID, (float[])dataBlock );
+		}
 	}
-
-	// ------------------------------------------------------
-
-
-
-
-
-
-	/*
-		//TODO VLADO: : H5Dwrite() exists for: byte[], double[], float[], int[], long[], short[]
-		//Byte
-		H5Dwrite( dataSetId, H5T_NATIVE_INT8, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
-		//Short
-		H5Dwrite( dataSetId, H5T_NATIVE_INT16, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
-		//Int
-		H5Dwrite( dataSetId, H5T_NATIVE_INT32, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
-		//Long
-		H5Dwrite( dataSetId, H5T_NATIVE_INT64, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
-		H5Dwrite( dataSetId, H5T_NATIVE_FLOAT, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
-		H5Dwrite( dataSetId, H5T_NATIVE_DOUBLE, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
-	*/
 }

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -53,17 +53,50 @@ import ch.systemsx.cisd.base.mdarray.MDLongArray;
 import ch.systemsx.cisd.base.mdarray.MDFloatArray;
 import ch.systemsx.cisd.base.mdarray.MDDoubleArray;
 
+//for the WriteSequenceToHdf5
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+
+//to create the right object
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
 
 class Hdf5BlockWriterPixelTypes
 {
 	interface PixelTypeMaintainer
 	{
-		//for the HDF5AccessHack
+		///for the HDF5AccessHack
 		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data);
 
-		//for the HDF5Access
+		///for the HDF5Access
 		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features);
 		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset);
+
+		///for the WriteSequenceToHdf5
+		ArrayImg<?,?> createArrayImg(final long[] dims);
+	}
+
+	/**
+	 * A factory to provide the right implementation of the PixelTypeMaintainer
+	 * interface given the input pxType parameter. The parameter should extend
+	 * imglib2's RealType to be recognized, otherwise an exception is thrown.
+	 */
+	static
+	PixelTypeMaintainer createPixelMaintainer(final Object pxType)
+	{
+		if (pxType instanceof ByteType) return new ByteTypeMaintainer();
+		else
+		if (pxType instanceof UnsignedByteType) return new UnsignedByteTypeMaintainer();
+		else
+		if (pxType instanceof ShortType) return new ShortTypeMaintainer();
+		else
+		if (pxType instanceof UnsignedShortType) return new UnsignedShortTypeMaintainer();
+		else
+			throw new IllegalArgumentException("Unrecognized pixel type, cannot save HDF5");
 	}
 
 	// ------------------------------------------------------
@@ -90,6 +123,13 @@ class Hdf5BlockWriterPixelTypes
 			final MDByteArray array = new MDByteArray( (byte[])data, reorderedDimensions );
 			hdf5Writer.int8().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
 		}
+
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final long[] dims)
+		{
+			return ArrayImgs.bytes(dims);
+		}
 	}
 
 	static class UnsignedByteTypeMaintainer implements PixelTypeMaintainer
@@ -114,6 +154,13 @@ class Hdf5BlockWriterPixelTypes
 		{
 			final MDByteArray array = new MDByteArray( (byte[])data, reorderedDimensions );
 			hdf5Writer.int8().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		}
+
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final long[] dims)
+		{
+			return ArrayImgs.unsignedBytes(dims);
 		}
 	}
 
@@ -141,6 +188,13 @@ class Hdf5BlockWriterPixelTypes
 			final MDShortArray array = new MDShortArray( (short[])data, reorderedDimensions );
 			hdf5Writer.int16().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
 		}
+
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final long[] dims)
+		{
+			return ArrayImgs.shorts(dims);
+		}
 	}
 
 	static class UnsignedShortTypeMaintainer implements PixelTypeMaintainer
@@ -165,6 +219,13 @@ class Hdf5BlockWriterPixelTypes
 		{
 			final MDShortArray array = new MDShortArray( (short[])data, reorderedDimensions );
 			hdf5Writer.int16().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		}
+
+		@Override
+		public
+		ArrayImg<?,?> createArrayImg(final long[] dims)
+		{
+			return ArrayImgs.unsignedShorts(dims);
 		}
 	}
 

--- a/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterPixelTypes.java
@@ -1,0 +1,192 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.export;
+
+//for the HDF5AccessHack
+import static ch.systemsx.cisd.hdf5.hdf5lib.H5D.H5Dwrite;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5P_DEFAULT;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_INT8;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_INT16;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_INT32;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_INT64;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_UINT8;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_UINT16;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_UINT32;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_UINT64;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_FLOAT;
+import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_DOUBLE;
+
+//for the HDF5Access
+import ch.systemsx.cisd.hdf5.IHDF5Writer;
+import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
+import ch.systemsx.cisd.base.mdarray.MDByteArray;
+import ch.systemsx.cisd.base.mdarray.MDShortArray;
+import ch.systemsx.cisd.base.mdarray.MDIntArray;
+import ch.systemsx.cisd.base.mdarray.MDLongArray;
+import ch.systemsx.cisd.base.mdarray.MDFloatArray;
+import ch.systemsx.cisd.base.mdarray.MDDoubleArray;
+
+
+class Hdf5BlockWriterPixelTypes
+{
+	interface PixelTypeMaintainer
+	{
+		//for the HDF5AccessHack
+		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data);
+
+		//for the HDF5Access
+		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features);
+		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset);
+	}
+
+	// ------------------------------------------------------
+	static class ByteTypeMaintainer implements PixelTypeMaintainer
+	{
+		@Override
+		public
+		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
+		{
+			return H5Dwrite(dataset_id, H5T_NATIVE_INT8, mem_space_id, file_space_id, H5P_DEFAULT, (byte[])data);
+		}
+
+		@Override
+		public
+		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features)
+		{
+			hdf5Writer.int8().createMDArray( path, dimensions, cellDimensions, features );
+		}
+
+		@Override
+		public
+		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset)
+		{
+			final MDByteArray array = new MDByteArray( (byte[])data, reorderedDimensions );
+			hdf5Writer.int8().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		}
+	}
+
+	static class UnsignedByteTypeMaintainer implements PixelTypeMaintainer
+	{
+		@Override
+		public
+		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
+		{
+			return H5Dwrite(dataset_id, H5T_NATIVE_UINT8, mem_space_id, file_space_id, H5P_DEFAULT, (byte[])data);
+		}
+
+		@Override
+		public
+		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features)
+		{
+			hdf5Writer.int8().createMDArray( path, dimensions, cellDimensions, features );
+		}
+
+		@Override
+		public
+		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset)
+		{
+			final MDByteArray array = new MDByteArray( (byte[])data, reorderedDimensions );
+			hdf5Writer.int8().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		}
+	}
+
+	// ------------------------------------------------------
+	static class ShortTypeMaintainer implements PixelTypeMaintainer
+	{
+		@Override
+		public
+		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
+		{
+			return H5Dwrite(dataset_id, H5T_NATIVE_INT16, mem_space_id, file_space_id, H5P_DEFAULT, (short[])data);
+		}
+
+		@Override
+		public
+		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features)
+		{
+			hdf5Writer.int16().createMDArray( path, dimensions, cellDimensions, features );
+		}
+
+		@Override
+		public
+		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset)
+		{
+			final MDShortArray array = new MDShortArray( (short[])data, reorderedDimensions );
+			hdf5Writer.int16().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		}
+	}
+
+	static class UnsignedShortTypeMaintainer implements PixelTypeMaintainer
+	{
+		@Override
+		public
+		int h5Dwrite(int dataset_id, int mem_space_id, int file_space_id, Object data)
+		{
+			return H5Dwrite(dataset_id, H5T_NATIVE_UINT16, mem_space_id, file_space_id, H5P_DEFAULT, (short[])data);
+		}
+
+		@Override
+		public
+		void createAndOpenDataset(final IHDF5Writer hdf5Writer, final String path, final long[] dimensions, final int[] cellDimensions, final HDF5IntStorageFeatures features)
+		{
+			hdf5Writer.int16().createMDArray( path, dimensions, cellDimensions, features );
+		}
+
+		@Override
+		public
+		void hdf5writer(final IHDF5Writer hdf5Writer, Object data, final long[] reorderedDimensions, final String datasetPath, final long[] reorderedOffset)
+		{
+			final MDShortArray array = new MDShortArray( (short[])data, reorderedDimensions );
+			hdf5Writer.int16().writeMDArrayBlockWithOffset( datasetPath, array, reorderedOffset );
+		}
+	}
+
+	// ------------------------------------------------------
+
+
+
+
+
+
+
+	/*
+		//TODO VLADO: : H5Dwrite() exists for: byte[], double[], float[], int[], long[], short[]
+		//Byte
+		H5Dwrite( dataSetId, H5T_NATIVE_INT8, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
+		//Short
+		H5Dwrite( dataSetId, H5T_NATIVE_INT16, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
+		//Int
+		H5Dwrite( dataSetId, H5T_NATIVE_INT32, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
+		//Long
+		H5Dwrite( dataSetId, H5T_NATIVE_INT64, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
+		H5Dwrite( dataSetId, H5T_NATIVE_FLOAT, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
+		H5Dwrite( dataSetId, H5T_NATIVE_DOUBLE, memorySpaceId, fileSpaceId, H5P_DEFAULT, data );
+	*/
+}

--- a/src/main/java/bdv/export/Hdf5BlockWriterThread.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterThread.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import bdv.export.Hdf5BlockWriterPixelTypes.PixelTypeMaintainer;
 import ch.systemsx.cisd.hdf5.HDF5Factory;
 import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
@@ -65,18 +66,19 @@ class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 		setName( "HDF5BlockWriterQueue" );
 	}
 
-	public Hdf5BlockWriterThread( final File hdf5File, final int queueLength )
+	//this constructor touches the file by setting up an file-feeding interface Hdf5Task
+	public Hdf5BlockWriterThread( final File hdf5File, final int queueLength, final PixelTypeMaintainer pxM )
 	{
 		final IHDF5Writer hdf5Writer = HDF5Factory.open( hdf5File );
 		IHDF5Access hdf5Access;
 		try
 		{
-			hdf5Access = new HDF5AccessHack( hdf5Writer );
+			hdf5Access = new HDF5AccessHack( hdf5Writer, pxM );
 		}
 		catch ( final Exception e )
 		{
 			e.printStackTrace();
-			hdf5Access = new HDF5Access( hdf5Writer );
+			hdf5Access = new HDF5Access( hdf5Writer, pxM );
 		}
 		this.hdf5Access = hdf5Access;
 		queue = new ArrayBlockingQueue<>( queueLength );
@@ -84,9 +86,9 @@ class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 		setName( "HDF5BlockWriterQueue" );
 	}
 
-	public Hdf5BlockWriterThread( final String hdf5FilePath, final int queueLength )
+	public Hdf5BlockWriterThread( final String hdf5FilePath, final int queueLength, final PixelTypeMaintainer pxM )
 	{
-		this( new File( hdf5FilePath), queueLength );
+		this( new File( hdf5FilePath), queueLength, pxM );
 	}
 
 	@Override

--- a/src/main/java/bdv/export/Hdf5BlockWriterThread.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterThread.java
@@ -162,7 +162,7 @@ class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 	}
 
 	@Override
-	public void writeBlockWithOffset( final short[] data, final long[] blockDimensions, final long[] offset )
+	public void writeBlockWithOffset( final Object data, final long[] blockDimensions, final long[] offset )
 	{
 		put( new WriteBlockWithOffsetTask( data, blockDimensions, offset ) );
 	}
@@ -233,13 +233,13 @@ class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 
 	private static class WriteBlockWithOffsetTask implements Hdf5BlockWriterThread.Hdf5Task
 	{
-		private final short[] data;
+		private final Object data;
 
 		private final long[] blockDimensions;
 
 		private final long[] offset;
 
-		public WriteBlockWithOffsetTask( final short[] data, final long[] blockDimensions, final long[] offset )
+		public WriteBlockWithOffsetTask( final Object data, final long[] blockDimensions, final long[] offset )
 		{
 			this.data = data;
 			this.blockDimensions = blockDimensions;

--- a/src/main/java/bdv/export/Hdf5BlockWriterThread.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterThread.java
@@ -67,7 +67,7 @@ class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 	}
 
 	//this constructor touches the file by setting up an file-feeding interface Hdf5Task
-	public Hdf5BlockWriterThread( final File hdf5File, final int queueLength, final PixelTypeMaintainer pxM )
+	public Hdf5BlockWriterThread( final File hdf5File, final int queueLength, final PixelTypeMaintainer<?> pxM )
 	{
 		final IHDF5Writer hdf5Writer = HDF5Factory.open( hdf5File );
 		IHDF5Access hdf5Access;
@@ -86,7 +86,7 @@ class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 		setName( "HDF5BlockWriterQueue" );
 	}
 
-	public Hdf5BlockWriterThread( final String hdf5FilePath, final int queueLength, final PixelTypeMaintainer pxM )
+	public Hdf5BlockWriterThread( final String hdf5FilePath, final int queueLength, final PixelTypeMaintainer<?> pxM )
 	{
 		this( new File( hdf5FilePath), queueLength, pxM );
 	}

--- a/src/main/java/bdv/export/Hdf5BlockWriterThread.java
+++ b/src/main/java/bdv/export/Hdf5BlockWriterThread.java
@@ -38,6 +38,12 @@ import ch.systemsx.cisd.hdf5.HDF5Factory;
 import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
 
+/**
+ * This class is merely a HDF5 front-end writer to both HDF5AccessHack
+ * and HDF5Access back-end writers. The latter two indeed call the HDF5
+ * library to implement the saving. This class offers basic (high-level)
+ * methods to populate the output HDF5 file by issuing HDF5 writing tasks/jobs.
+ */
 class Hdf5BlockWriterThread extends Thread implements IHDF5Access
 {
 	private final IHDF5Access hdf5Access;

--- a/src/main/java/bdv/export/IHDF5Access.java
+++ b/src/main/java/bdv/export/IHDF5Access.java
@@ -45,10 +45,13 @@ interface IHDF5Access
 
 	/**
 	 * This is the main method that pushes image/voxel data into the HDF5 file.
-	 * There would need to be multiple clones of it, each for specific voxel types,
+	 * There needs to be multiple clones of it, each for specific voxel types,
 	 * as on the HDF5-side this should end up as different HDF5 library calls.
+	 *
+	 * The parameter 'data' is assumed to be an array of Java basic data type, in fact
+	 * any basic type that can be covered/mapped/wrapped with imglibs2.NativeType.
 	 */
-	public void writeBlockWithOffset( final short[] data, final long[] blockDimensions, final long[] offset );
+	public void writeBlockWithOffset( final Object data, final long[] blockDimensions, final long[] offset );
 
 	public void closeDataset();
 

--- a/src/main/java/bdv/export/IHDF5Access.java
+++ b/src/main/java/bdv/export/IHDF5Access.java
@@ -32,12 +32,22 @@ package bdv.export;
 import ch.systemsx.cisd.hdf5.HDF5IntStorageFeatures;
 import ch.systemsx.cisd.hdf5.IHDF5Writer;
 
+/**
+ * A connection interface between HDF5 library calls and BDV (image) data feeders.
+ * The HDF5-side implements this interface in HDF5Access*java files/classes.
+ * The BDV-side implements this interface in Hdf5BlockWriterThread.java.
+ */
 interface IHDF5Access
 {
 	public void writeMipmapDescription( final int setupIdPartition, final ExportMipmapInfo mipmapInfo );
 
 	public void createAndOpenDataset( final String path, long[] dimensions, int[] cellDimensions, HDF5IntStorageFeatures features );
 
+	/**
+	 * This is the main method that pushes image/voxel data into the HDF5 file.
+	 * There would need to be multiple clones of it, each for specific voxel types,
+	 * as on the HDF5-side this should end up as different HDF5 library calls.
+	 */
 	public void writeBlockWithOffset( final short[] data, final long[] blockDimensions, final long[] offset );
 
 	public void closeDataset();

--- a/src/main/java/bdv/export/WriteSequenceToHdf5.java
+++ b/src/main/java/bdv/export/WriteSequenceToHdf5.java
@@ -39,8 +39,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
 
 import static bdv.export.Hdf5BlockWriterPixelTypes.*;
-import bdv.export.WriteSequenceToHdf5.AfterEachPlane;
-import bdv.export.WriteSequenceToHdf5.LoopbackHeuristic;
 import bdv.img.hdf5.Hdf5ImageLoader;
 import bdv.img.hdf5.Partition;
 import bdv.img.hdf5.Util;
@@ -63,7 +61,7 @@ import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImg;
-import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.img.cell.CellImg;
 import net.imglib2.iterator.LocalizingIntervalIterator;
 import net.imglib2.type.NativeType;
@@ -800,9 +798,8 @@ public class WriteSequenceToHdf5
 								else
 									downsampleBlock( cell.cursor(), accumulator, currentCellDim, in, blockMin, factor, scale );
 
-								//TODO VLADO, here's the actual saving into HDF5!!
-								//TODO VLADO: data should be of type Object
-								writerQueue.writeBlockWithOffset( ( ( ShortArray ) cell.update( null ) ).getCurrentStorageArray(), currentCellDim.clone(), currentCellMin.clone() );
+								//here comes the actual saving into HDF5
+								writerQueue.writeBlockWithOffset( ( ( ArrayDataAccess<?> ) cell.update( null ) ).getCurrentStorageArray(), currentCellDim.clone(), currentCellMin.clone() );
 							}
 							doneSignal.countDown();
 						}

--- a/src/main/java/bdv/export/WriteSequenceToHdf5.java
+++ b/src/main/java/bdv/export/WriteSequenceToHdf5.java
@@ -405,6 +405,7 @@ public class WriteSequenceToHdf5
 		final File hdf5File = new File( partition.getPath() );
 		if ( hdf5File.exists() )
 			hdf5File.delete();
+		System.out.println("(w) voxel type: "+pxM.reportPixelType());
 		final Hdf5BlockWriterThread writerQueue = new Hdf5BlockWriterThread( hdf5File, blockWriterQueueLength, pxM );
 		writerQueue.start();
 
@@ -534,6 +535,7 @@ public class WriteSequenceToHdf5
 			= Hdf5BlockWriterPixelTypes.createPixelMaintainer( img.randomAccess().get() );
 
 		// create and start Hdf5BlockWriterThread
+		System.out.println("(w) voxel type: "+pxM.reportPixelType());
 		final Hdf5BlockWriterThread writerQueue = new Hdf5BlockWriterThread( partition.getPath(), blockWriterQueueLength, pxM );
 		writerQueue.start();
 		final CellCreatorThread[] cellCreatorThreads = createAndStartCellCreatorThreads( numCellCreatorThreads );

--- a/src/main/java/bdv/export/WriteSequenceToHdf5.java
+++ b/src/main/java/bdv/export/WriteSequenceToHdf5.java
@@ -392,8 +392,8 @@ public class WriteSequenceToHdf5
 			//determine which PixelTypeMaintainer we will use
 			if (pxM == null) pxM = Hdf5BlockWriterPixelTypes.createPixelMaintainer(type);
 
-			//check that all setups are holding images of the voxel type
-			//NB: this is probably not required due to the way the views are constructed (blame VLADO that he was lazy to understand that)
+			//check that all setups are holding images of the same voxel type
+			//first iteration just remembers the pxType, all consequent iterations check against it
 			if (pxType == null) pxType = type;
 			else if ( !pxType.equals(type) )
 				throw new IllegalArgumentException( "All image data must be of the same type which seems to "+pxType.getClass().getSimpleName()

--- a/src/main/java/bdv/export/WriteSequenceToHdf5.java
+++ b/src/main/java/bdv/export/WriteSequenceToHdf5.java
@@ -384,7 +384,7 @@ public class WriteSequenceToHdf5
 		final BasicImgLoader imgLoader = seq.getImgLoader();
 
 		//create a proper handler for this particular pixel type
-		PixelTypeMaintainer pxM = null;
+		PixelTypeMaintainer<T> pxM = null;
 		Object pxType = null;
 
 		for ( final BasicViewSetup setup : seq.getViewSetupsOrdered() ) {
@@ -531,7 +531,7 @@ public class WriteSequenceToHdf5
 		final int blockWriterQueueLength = 100;
 
 		//create a proper handler for this particular pixel type
-		final PixelTypeMaintainer pxM
+		final PixelTypeMaintainer<T> pxM
 			= Hdf5BlockWriterPixelTypes.createPixelMaintainer( img.randomAccess().get() );
 
 		// create and start Hdf5BlockWriterThread
@@ -626,7 +626,7 @@ public class WriteSequenceToHdf5
 			progressWriter = new ProgressWriterConsole();
 
 		//create a proper handler for this particular pixel type
-		final PixelTypeMaintainer pxM
+		final PixelTypeMaintainer<T> pxM
 			= Hdf5BlockWriterPixelTypes.createPixelMaintainer( img.randomAccess().get() );
 
 		// for progressWriter
@@ -788,12 +788,7 @@ public class WriteSequenceToHdf5
 									currentCellMax[ d ] = currentCellMin[ d ] + currentCellDim[ d ] - 1;
 								}
 
-								//we need to rely on the assumption that pxM was created appropriately for the
-								//type T so that its createArrayImg() method is indeed creating ArrayImg<T,?>
-								//
-								//or, we need to pull T into PixelTypeMaintainer's signature so that compiler would
-								//see the type of the returned object... TODO VLADO
-								final ArrayImg< T, ? > cell = (ArrayImg<T, ?>) pxM.createArrayImg( currentCellDim );
+								final ArrayImg< T, ? > cell = pxM.createArrayImg( currentCellDim );
 								if ( fullResolution )
 									copyBlock( cell.randomAccess(), currentCellDim, in, blockMin );
 								else

--- a/src/main/java/bdv/export/WriteSequenceToHdf5.java
+++ b/src/main/java/bdv/export/WriteSequenceToHdf5.java
@@ -38,7 +38,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
 
-import static bdv.export.Hdf5BlockWriterPixelTypes.*;
+import bdv.export.Hdf5BlockWriterPixelTypes;
+import bdv.export.Hdf5BlockWriterPixelTypes.PixelTypeMaintainer;
 import bdv.img.hdf5.Hdf5ImageLoader;
 import bdv.img.hdf5.Partition;
 import bdv.img.hdf5.Util;
@@ -389,7 +390,7 @@ public class WriteSequenceToHdf5
 		for ( final BasicViewSetup setup : seq.getViewSetupsOrdered() ) {
 			final Object type = imgLoader.getSetupImgLoader( setup.getId() ).getImageType();
 			//determine which PixelTypeMaintainer we will use
-			if (pxM == null) pxM = createPixelMaintainer(type);
+			if (pxM == null) pxM = Hdf5BlockWriterPixelTypes.createPixelMaintainer(type);
 
 			//check that all setups are holding images of the voxel type
 			//NB: this is probably not required due to the way the views are constructed (blame VLADO that he was lazy to understand that)
@@ -530,7 +531,7 @@ public class WriteSequenceToHdf5
 
 		//create a proper handler for this particular pixel type
 		final PixelTypeMaintainer pxM
-			= createPixelMaintainer( img.randomAccess().get() );
+			= Hdf5BlockWriterPixelTypes.createPixelMaintainer( img.randomAccess().get() );
 
 		// create and start Hdf5BlockWriterThread
 		final Hdf5BlockWriterThread writerQueue = new Hdf5BlockWriterThread( partition.getPath(), blockWriterQueueLength, pxM );
@@ -624,7 +625,7 @@ public class WriteSequenceToHdf5
 
 		//create a proper handler for this particular pixel type
 		final PixelTypeMaintainer pxM
-			= createPixelMaintainer( img.randomAccess().get() );
+			= Hdf5BlockWriterPixelTypes.createPixelMaintainer( img.randomAccess().get() );
 
 		// for progressWriter
 		final int numTasks = mipmapInfo.getNumLevels();

--- a/src/main/java/bdv/export/WriteSequenceToHdf5.java
+++ b/src/main/java/bdv/export/WriteSequenceToHdf5.java
@@ -394,7 +394,7 @@ public class WriteSequenceToHdf5
 
 			//check that all setups are holding images of the voxel type
 			//NB: this is probably not required due to the way the views are constructed (blame VLADO that he was lazy to understand that)
-			if (pxType == null) pxType = type; //TODO VLADO check that it works like this
+			if (pxType == null) pxType = type;
 			else if ( !pxType.equals(type) )
 				throw new IllegalArgumentException( "All image data must be of the same type which seems to "+pxType.getClass().getSimpleName()
 				  + " in this case.\nCurrently writing to HDF5 is only supported for single type accross all midmaps, views, time points." );

--- a/src/main/java/bdv/img/hdf5/HDF5Access.java
+++ b/src/main/java/bdv/img/hdf5/HDF5Access.java
@@ -31,6 +31,8 @@ package bdv.img.hdf5;
 
 import static bdv.img.hdf5.Util.reorder;
 import static bdv.export.Hdf5BlockWriterPixelTypes.PixelTypeMaintainer;
+
+import ch.systemsx.cisd.base.mdarray.MDAbstractArray;
 import ch.systemsx.cisd.base.mdarray.MDFloatArray;
 import ch.systemsx.cisd.base.mdarray.MDShortArray;
 import ch.systemsx.cisd.hdf5.HDF5DataSetInformation;
@@ -70,26 +72,20 @@ class HDF5Access implements IHDF5Access
 			return new DimsAndExistence( new long[] { 1, 1, 1 }, false );
 	}
 
-	@Override
-	public synchronized short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	//local skeleton to be re-used in the front-ends below
+	private synchronized Object readMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
 	{
 		if ( Thread.interrupted() )
 			throw new InterruptedException();
 		Util.reorder( dimensions, reorderedDimensions );
 		Util.reorder( min, reorderedMin );
-		final MDShortArray array = hdf5Reader.int16().readMDArrayBlockWithOffset( Util.getCellsPath( timepoint, setup, level ), reorderedDimensions, reorderedMin );
+		//TODO
+		final MDAbstractArray<?> array = px.hdf5Reader.int16().readMDArrayBlockWithOffset( Util.getCellsPath( timepoint, setup, level ), reorderedDimensions, reorderedMin );
 		return array.getAsFlatArray();
 	}
 
-	@Override
-	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final short[] dataBlock ) throws InterruptedException
-	{
-		System.arraycopy( readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
-		return dataBlock;
-	}
-
-	@Override
-	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	//local skeleton to be re-used in the front-ends below
+	private float[] readMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
 	{
 		if ( Thread.interrupted() )
 			throw new InterruptedException();
@@ -97,14 +93,77 @@ class HDF5Access implements IHDF5Access
 		Util.reorder( min, reorderedMin );
 		final MDFloatArray array = hdf5Reader.float32().readMDArrayBlockWithOffset( Util.getCellsPath( timepoint, setup, level ), reorderedDimensions, reorderedMin );
 		final float[] pixels = array.getAsFlatArray();
-		unsignedShort( pixels );
+		px.unsignedShort( pixels ); //TODO
 		return pixels;
 	}
 
 	@Override
+	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return (byte[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final byte[] dataBlock ) throws InterruptedException
+	{
+		System.arraycopy( (byte[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
+		return dataBlock;
+	}
+
+	@Override
+	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return (short[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final short[] dataBlock ) throws InterruptedException
+	{
+		System.arraycopy( (short[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
+		return dataBlock;
+	}
+
+	@Override
+	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return (float[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		System.arraycopy( (float[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
+		return dataBlock;
+	}
+
+	@Override
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		System.arraycopy( readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
+		return dataBlock;
+	}
+	@Override
+	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+	}
+	@Override
 	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
 	{
-		System.arraycopy( readShortMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
+		System.arraycopy( readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
+		return dataBlock;
+	}
+	@Override
+	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		System.arraycopy( readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min ), 0, dataBlock, 0, dataBlock.length );
 		return dataBlock;
 	}
 

--- a/src/main/java/bdv/img/hdf5/HDF5Access.java
+++ b/src/main/java/bdv/img/hdf5/HDF5Access.java
@@ -40,13 +40,13 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
 class HDF5Access implements IHDF5Access
 {
 	private final IHDF5Reader hdf5Reader;
-	private final PixelTypeMaintainer px;
+	private final PixelTypeMaintainer<?> px;
 
 	private final int[] reorderedDimensions = new int[ 3 ];
 
 	private final long[] reorderedMin = new long[ 3 ];
 
-	public HDF5Access( final IHDF5Reader hdf5Reader, final PixelTypeMaintainer px )
+	public HDF5Access( final IHDF5Reader hdf5Reader, final PixelTypeMaintainer<?> px )
 	{
 		this.hdf5Reader = hdf5Reader;
 		this.px = px;

--- a/src/main/java/bdv/img/hdf5/HDF5Access.java
+++ b/src/main/java/bdv/img/hdf5/HDF5Access.java
@@ -30,6 +30,7 @@
 package bdv.img.hdf5;
 
 import static bdv.img.hdf5.Util.reorder;
+import static bdv.export.Hdf5BlockWriterPixelTypes.PixelTypeMaintainer;
 import ch.systemsx.cisd.base.mdarray.MDFloatArray;
 import ch.systemsx.cisd.base.mdarray.MDShortArray;
 import ch.systemsx.cisd.hdf5.HDF5DataSetInformation;
@@ -38,14 +39,16 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
 class HDF5Access implements IHDF5Access
 {
 	private final IHDF5Reader hdf5Reader;
+	private final PixelTypeMaintainer px;
 
 	private final int[] reorderedDimensions = new int[ 3 ];
 
 	private final long[] reorderedMin = new long[ 3 ];
 
-	public HDF5Access( final IHDF5Reader hdf5Reader )
+	public HDF5Access( final IHDF5Reader hdf5Reader, final PixelTypeMaintainer px )
 	{
 		this.hdf5Reader = hdf5Reader;
+		this.px = px;
 	}
 
 	@Override

--- a/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
+++ b/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
@@ -30,6 +30,7 @@
 package bdv.img.hdf5;
 
 import static bdv.img.hdf5.Util.reorder;
+import static bdv.export.Hdf5BlockWriterPixelTypes.PixelTypeMaintainer;
 import static ch.systemsx.cisd.hdf5.hdf5lib.H5D.H5Dclose;
 import static ch.systemsx.cisd.hdf5.hdf5lib.H5D.H5Dget_space;
 import static ch.systemsx.cisd.hdf5.hdf5lib.H5D.H5Dopen;
@@ -63,6 +64,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
 class HDF5AccessHack implements IHDF5Access
 {
 	private final IHDF5Reader hdf5Reader;
+	private final PixelTypeMaintainer px;
 
 	private final int fileId;
 
@@ -128,9 +130,11 @@ class HDF5AccessHack implements IHDF5Access
 
 	private final OpenDataSetCache openDataSetCache;
 
-	public HDF5AccessHack( final IHDF5Reader hdf5Reader ) throws ClassNotFoundException, SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException
+	public HDF5AccessHack( final IHDF5Reader hdf5Reader, final PixelTypeMaintainer px )
+	throws ClassNotFoundException, SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException
 	{
 		this.hdf5Reader = hdf5Reader;
+		this.px = px;
 
 		final Class< ? > k = Class.forName( "ch.systemsx.cisd.hdf5.HDF5Reader" );
 		final Field f = k.getDeclaredField( "baseReader" );

--- a/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
+++ b/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
@@ -180,16 +180,8 @@ class HDF5AccessHack implements IHDF5Access
 			return new DimsAndExistence( new long[] { 1, 1, 1 }, false );
 	}
 
-	@Override
-	public synchronized short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
-	{
-		final short[] dataBlock = new short[ dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ] ];
-		readShortMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
-		return dataBlock;
-	}
-
-	@Override
-	public synchronized short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final short[] dataBlock ) throws InterruptedException
+	//local skeleton to be re-used in the front-ends below
+	private synchronized Object readMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final Object dataBlock ) throws InterruptedException
 	{
 		if ( Thread.interrupted() )
 			throw new InterruptedException();
@@ -199,22 +191,21 @@ class HDF5AccessHack implements IHDF5Access
 		final OpenDataSet dataset = openDataSetCache.getDataSet( new ViewLevelId( timepoint, setup, level ) );
 		final int memorySpaceId = H5Screate_simple( reorderedDimensions.length, reorderedDimensions, null );
 		H5Sselect_hyperslab( dataset.fileSpaceId, H5S_SELECT_SET, reorderedMin, null, reorderedDimensions, null );
-		H5Dread( dataset.dataSetId, H5T_NATIVE_INT16, memorySpaceId, dataset.fileSpaceId, numericConversionXferPropertyListID, dataBlock );
+		px.H5Dread( dataset.dataSetId, H5T_NATIVE_INT16, memorySpaceId, dataset.fileSpaceId, numericConversionXferPropertyListID, dataBlock ); //TODO
 		H5Sclose( memorySpaceId );
 
 		return dataBlock;
 	}
 
-	@Override
-	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	//local skeleton to be re-used in the front-ends below
+	private float[] readMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
 	{
 		final float[] dataBlock = new float[ dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ] ];
-		readShortMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
+		readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
 		return dataBlock;
 	}
 
-	@Override
-	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	private float[] readMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
 	{
 		if ( Thread.interrupted() )
 			throw new InterruptedException();
@@ -226,8 +217,78 @@ class HDF5AccessHack implements IHDF5Access
 		H5Sselect_hyperslab( dataset.fileSpaceId, H5S_SELECT_SET, reorderedMin, null, reorderedDimensions, null );
 		H5Dread( dataset.dataSetId, H5T_NATIVE_FLOAT, memorySpaceId, dataset.fileSpaceId, numericConversionXferPropertyListID, dataBlock );
 		H5Sclose( memorySpaceId );
-		HDF5Access.unsignedShort( dataBlock );
+		px.HDF5Access.unsignedShort( dataBlock ); //TODO rename
 		return dataBlock;
+	}
+
+	@Override
+	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		final byte[] dataBlock = new byte[ dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ] ];
+		readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
+		return dataBlock;
+	}
+	@Override
+	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final byte[] dataBlock ) throws InterruptedException
+	{
+		return (byte[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
+	}
+
+	@Override
+	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		final short[] dataBlock = new short[ dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ] ];
+		readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
+		return dataBlock;
+	}
+	@Override
+	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final short[] dataBlock ) throws InterruptedException
+	{
+		return (short[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
+	}
+
+	@Override
+	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		final float[] dataBlock = new float[ dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ] ];
+		readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
+		return dataBlock;
+	}
+	@Override
+	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		return (float[])readMDArrayBlockWithOffset( timepoint, setup, level, dimensions, min, dataBlock );
+	}
+
+	@Override
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
+	}
+	@Override
+	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
+	}
+	@Override
+	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+	}
+	@Override
+	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
+	{
+		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
 	}
 
 	@Override

--- a/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
+++ b/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
@@ -43,7 +43,6 @@ import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5P_DEFAULT;
 import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5S_MAX_RANK;
 import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5S_SELECT_SET;
 import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_FLOAT;
-import static ch.systemsx.cisd.hdf5.hdf5lib.HDF5Constants.H5T_NATIVE_INT16;
 
 import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
@@ -191,7 +190,7 @@ class HDF5AccessHack implements IHDF5Access
 		final OpenDataSet dataset = openDataSetCache.getDataSet( new ViewLevelId( timepoint, setup, level ) );
 		final int memorySpaceId = H5Screate_simple( reorderedDimensions.length, reorderedDimensions, null );
 		H5Sselect_hyperslab( dataset.fileSpaceId, H5S_SELECT_SET, reorderedMin, null, reorderedDimensions, null );
-		px.H5Dread( dataset.dataSetId, H5T_NATIVE_INT16, memorySpaceId, dataset.fileSpaceId, numericConversionXferPropertyListID, dataBlock ); //TODO
+		px.h5Dread( dataset.dataSetId, memorySpaceId, dataset.fileSpaceId, numericConversionXferPropertyListID, dataBlock );
 		H5Sclose( memorySpaceId );
 
 		return dataBlock;
@@ -217,7 +216,7 @@ class HDF5AccessHack implements IHDF5Access
 		H5Sselect_hyperslab( dataset.fileSpaceId, H5S_SELECT_SET, reorderedMin, null, reorderedDimensions, null );
 		H5Dread( dataset.dataSetId, H5T_NATIVE_FLOAT, memorySpaceId, dataset.fileSpaceId, numericConversionXferPropertyListID, dataBlock );
 		H5Sclose( memorySpaceId );
-		px.HDF5Access.unsignedShort( dataBlock ); //TODO rename
+		//HDF5Access.unsignedShort( dataBlock ); //this one is done outside this function in the type-specific functions
 		return dataBlock;
 	}
 
@@ -263,22 +262,22 @@ class HDF5AccessHack implements IHDF5Access
 	@Override
 	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
 	{
-		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+		return HDF5Access.unsignedByte(readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min ));
 	}
 	@Override
 	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
 	{
-		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
+		return HDF5Access.unsignedByte(readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock ));
 	}
 	@Override
 	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException
 	{
-		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min );
+		return HDF5Access.unsignedShort(readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min ));
 	}
 	@Override
 	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException
 	{
-		return readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock );
+		return HDF5Access.unsignedShort(readMDArrayBlockWithOffsetAsFloat( timepoint, setup, level, dimensions, min, dataBlock ));
 	}
 	@Override
 	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException

--- a/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
+++ b/src/main/java/bdv/img/hdf5/HDF5AccessHack.java
@@ -63,7 +63,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
 class HDF5AccessHack implements IHDF5Access
 {
 	private final IHDF5Reader hdf5Reader;
-	private final PixelTypeMaintainer px;
+	private final PixelTypeMaintainer<?> px;
 
 	private final int fileId;
 
@@ -129,7 +129,7 @@ class HDF5AccessHack implements IHDF5Access
 
 	private final OpenDataSetCache openDataSetCache;
 
-	public HDF5AccessHack( final IHDF5Reader hdf5Reader, final PixelTypeMaintainer px )
+	public HDF5AccessHack( final IHDF5Reader hdf5Reader, final PixelTypeMaintainer<?> px )
 	throws ClassNotFoundException, SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException
 	{
 		this.hdf5Reader = hdf5Reader;

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -115,7 +115,12 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 
 	//TODO VLADO: this class could actually have an explicit memory of what
 	//            pixel type is inside the this.hdf5File
-	NativeType<?> hdf5PixelType = null;
+	//
+	//NB: The default value is UnsignedShortType,
+	//    change it if you know there is something different in the input file.
+	//NB: It is intentionally not final to allow to inject the specific voxel type
+	//    without having the need to change constructors.
+	String hdf5PixelType = new String("UnsignedShortType");
 
 	/**
 	 * Maps setup id to {@link SetupImgLoader}.

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -423,8 +423,8 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 		 */
 		private final MipmapInfo mipmapInfo;
 
-		protected SetupImgLoader( final int setupId, final MipmapInfo mipmapInfo,
-		                          final T type, final VT volatileType)
+		public SetupImgLoader( final int setupId, final MipmapInfo mipmapInfo,
+		                       final T type, final VT volatileType)
 		{
 			super( type, volatileType );
 			this.setupId = setupId;

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -114,14 +114,12 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 	//TODO VLADO: could be renamed, but is protected -> might be used is some code elsewhere
 	protected CacheArrayLoader<?> shortLoader;
 
-	//TODO VLADO: this class could actually have an explicit memory of what
-	//            pixel type is inside the this.hdf5File
-	//
+	//the memory of what pixel type is inside the this.hdf5File
 	//NB: The default value is UnsignedShortType,
 	//    change it if you know there is something different in the input file.
 	//NB: It is intentionally not final to allow to inject the specific voxel type
 	//    without having the need to change constructors.
-	String hdf5PixelType = new String("UnsignedShortType");
+	public String hdf5PixelType = new String("UnsignedShortType");
 
 	/**
 	 * Maps setup id to {@link SetupImgLoader}.

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -111,8 +111,14 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 
 	protected FetcherThreads fetchers;
 
-	//TODO VLADO: could be renamed, but is protected -> might be used is some code elsewhere
-	protected CacheArrayLoader<?> shortLoader;
+	//was: protected Hdf5VolatileShortArrayLoader shortLoader;
+	//
+	//despite it is protected, i.e. might be used in some class derived from this one,
+	//Vlado has decided to rename this attribute to intentionally make any down-stream
+	//class code non-compilable, pointing a developer to resolve the fact that the attribute
+	//is now of a type that is up-stream to the original Hdf5VolatileShortArrayLoader, i.e.
+	//that the new type is less specific
+	protected CacheArrayLoader<?> volatileArrayLoader;
 
 	//the memory of what pixel type is inside the this.hdf5File
 	//NB: The default value is UnsignedShortType,
@@ -244,7 +250,7 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 					hdf5Access = new HDF5Access( hdf5Reader, pxM );
 				}
 				//again, create appropriate type-specific implementation of the CacheArrayLoader<?>
-				shortLoader = pxM.createHdf5VolatileTypeArrayLoader( hdf5Access );
+				volatileArrayLoader = pxM.createHdf5VolatileTypeArrayLoader( hdf5Access );
 
 				final BlockingFetchQueues< Callable< ? > > queue = new BlockingFetchQueues<>( maxNumLevels );
 				fetchers = new FetcherThreads( queue, 1 );
@@ -330,7 +336,7 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 	public CacheArrayLoader<?> getShortArrayLoader()
 	{
 		open();
-		return shortLoader;
+		return volatileArrayLoader;
 	}
 
 	/**
@@ -582,7 +588,7 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 			final int priority = mipmapInfo.getMaxLevel() - level;
 			final CacheHints cacheHints = new CacheHints( loadingStrategy, priority, false );
 
-			return cache.createImg( grid, timepointId, setupId, level, cacheHints, shortLoader, type );
+			return cache.createImg( grid, timepointId, setupId, level, cacheHints, volatileArrayLoader, type );
 		}
 
 		/**

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -157,15 +157,30 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 	{
 		this( hdf5File, hdf5Partitions, sequenceDescription, true );
 	}
+	public Hdf5ImageLoader( final File hdf5File, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final String pxType )
+	{
+		this( hdf5File, hdf5Partitions, sequenceDescription, pxType, true );
+	}
 
 	public Hdf5ImageLoader( final File hdf5File, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final boolean doOpen )
 	{
 		this( hdf5File, null, hdf5Partitions, sequenceDescription, doOpen );
 	}
+	public Hdf5ImageLoader( final File hdf5File, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final String pxType, final boolean doOpen )
+	{
+		this( hdf5File, null, hdf5Partitions, sequenceDescription, pxType, doOpen );
+	}
 
+	///this is the former main constructor which was assuming that BDV HDF5 files are UINT16 only
 	protected Hdf5ImageLoader( final File hdf5File, final IHDF5Reader existingHdf5Reader, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final boolean doOpen )
 	{
+		this( hdf5File, null, hdf5Partitions, sequenceDescription, "UnsignedShortType", doOpen );
+	}
+	///this is the new main constructor which requires to know the voxel type of a BDV HDF5, the type is extracted from the associated XML
+	protected Hdf5ImageLoader( final File hdf5File, final IHDF5Reader existingHdf5Reader, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final String pxType, final boolean doOpen )
+	{
 		this.existingHdf5Reader = existingHdf5Reader;
+		this.hdf5PixelType = pxType;
 		this.hdf5File = hdf5File;
 		setupImgLoaders = new HashMap<>();
 		cachedDimsAndExistence = new HashMap<>();

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -180,7 +180,7 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 	///this is the former main constructor which was assuming that BDV HDF5 files are UINT16 only
 	protected Hdf5ImageLoader( final File hdf5File, final IHDF5Reader existingHdf5Reader, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final boolean doOpen )
 	{
-		this( hdf5File, null, hdf5Partitions, sequenceDescription, "UnsignedShortType", doOpen );
+		this( hdf5File, existingHdf5Reader, hdf5Partitions, sequenceDescription, "UnsignedShortType", doOpen );
 	}
 	///this is the new main constructor which requires to know the voxel type of a BDV HDF5, the type is extracted from the associated XML
 	protected Hdf5ImageLoader( final File hdf5File, final IHDF5Reader existingHdf5Reader, final ArrayList< Partition > hdf5Partitions, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription, final String pxType, final boolean doOpen )

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -222,12 +222,12 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 
 				try
 				{
-					hdf5Access = new HDF5AccessHack( hdf5Reader );
+					hdf5Access = new HDF5AccessHack( hdf5Reader, pxM );
 				}
 				catch ( final Exception e )
 				{
 					e.printStackTrace();
-					hdf5Access = new HDF5Access( hdf5Reader );
+					hdf5Access = new HDF5Access( hdf5Reader, pxM );
 				}
 				//again, create appropriate type-specific implementation of the CacheArrayLoader<?>
 				shortLoader = pxM.createHdf5VolatileTypeArrayLoader( hdf5Access );

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -232,6 +232,8 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 
 				cachedDimsAndExistence.clear();
 
+				System.out.println("(r) voxel type: "+this.hdf5PixelType);
+
 				try
 				{
 					hdf5Access = new HDF5AccessHack( hdf5Reader, pxM );

--- a/src/main/java/bdv/img/hdf5/Hdf5VolatileTypeArrayLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5VolatileTypeArrayLoader.java
@@ -37,9 +37,9 @@ public class Hdf5VolatileTypeArrayLoader <VT extends VolatileArrayDataAccess<VT>
 implements CacheArrayLoader< VT >
 {
 	private final IHDF5Access hdf5Access;
-	private final PixelTypeMaintainer px;
+	private final PixelTypeMaintainer<?> px;
 
-	public Hdf5VolatileTypeArrayLoader( final IHDF5Access hdf5Access, final PixelTypeMaintainer px )
+	public Hdf5VolatileTypeArrayLoader( final IHDF5Access hdf5Access, final PixelTypeMaintainer<?> px )
 	{
 		this.hdf5Access = hdf5Access;
 		this.px = px;
@@ -53,7 +53,7 @@ implements CacheArrayLoader< VT >
 	{
 		//NB: we cast back to the VT interface because we know that loadArray() (PixelTypeMaintainer)
 		//    always instantiates implementation of this interface
-		return (VT) px.loadArray(hdf5Access, timepoint, setup, level, dimensions, min );
+		return (VT) px.loadArray( hdf5Access, timepoint, setup, level, dimensions, min );
 	}
 
 	@Override

--- a/src/main/java/bdv/img/hdf5/IHDF5Access.java
+++ b/src/main/java/bdv/img/hdf5/IHDF5Access.java
@@ -35,17 +35,18 @@ public interface IHDF5Access
 
 	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
 	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final byte[] dataBlock ) throws InterruptedException;
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
 
 	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
 	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final short[] dataBlock ) throws InterruptedException;
+	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
 
 	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
 	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
-
-	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
-	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
-	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
-	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
+	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public float[] readFloatMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
 
 	public void closeAllDataSets();
 

--- a/src/main/java/bdv/img/hdf5/IHDF5Access.java
+++ b/src/main/java/bdv/img/hdf5/IHDF5Access.java
@@ -29,16 +29,22 @@
  */
 package bdv.img.hdf5;
 
-interface IHDF5Access
+public interface IHDF5Access
 {
 	public DimsAndExistence getDimsAndExistence( final ViewLevelId id );
 
-	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public byte[] readByteMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final byte[] dataBlock ) throws InterruptedException;
 
+	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
 	public short[] readShortMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final short[] dataBlock ) throws InterruptedException;
 
-	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public float[] readFloatMDArrayBlockWithOffset( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
 
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
+	public float[] readByteMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
+	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min ) throws InterruptedException;
 	public float[] readShortMDArrayBlockWithOffsetAsFloat( final int timepoint, final int setup, final int level, final int[] dimensions, final long[] min, final float[] dataBlock ) throws InterruptedException;
 
 	public void closeAllDataSets();

--- a/src/main/java/bdv/img/hdf5/XmlIoHdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/XmlIoHdf5ImageLoader.java
@@ -78,14 +78,10 @@ public class XmlIoHdf5ImageLoader implements XmlIoBasicImgLoader< Hdf5ImageLoade
 		for ( final Element p : elem.getChildren( "partition" ) )
 			partitions.add( partitionFromXml( p, basePath ) );
 
-		//create the loader the usual way, nothing has changed here
-		final Hdf5ImageLoader HDF5loader = new Hdf5ImageLoader( new File( path ), partitions, sequenceDescription );
-
-		//if we manage to read specific voxel type info, inject it;
-		//otherwise we don't change it, which leaves the HDF5loader
-		//with its default value (which is backward compatible UnsignedShortType)
-		if (pxType != null) HDF5loader.hdf5PixelType = pxType;
-
+		//create the loader either the old/usual way, or with explicit voxel type
+		final Hdf5ImageLoader HDF5loader = (pxType == null)
+			? new Hdf5ImageLoader( new File( path ), partitions, sequenceDescription )          //implicit voxel type
+			: new Hdf5ImageLoader( new File( path ), partitions, sequenceDescription, pxType ); //explicit voxel type
 		return HDF5loader;
 	}
 

--- a/src/main/java/net/imglib2/type/volatiles/VolatileByteType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileByteType.java
@@ -1,0 +1,146 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.volatiles;
+
+import net.imglib2.Volatile;
+import net.imglib2.img.NativeImg;
+import net.imglib2.img.NativeImgFactory;
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileByteAccess;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileByteArray;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.util.Fraction;
+
+/**
+ * A {@link Volatile} variant of {@link ByteType}. It uses an
+ * underlying {@link ByteType} that maps into a
+ * {@link VolatileByteAccess}.
+ *
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
+ * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
+ */
+public class VolatileByteType extends AbstractVolatileNativeRealType< ByteType, VolatileByteType >
+{
+	final protected NativeImg< ?, ? extends VolatileByteAccess > img;
+
+	private static class WrappedByteType extends ByteType
+	{
+		public WrappedByteType( final NativeImg<?, ? extends ByteAccess> img )
+		{
+			super( img );
+		}
+
+		public WrappedByteType( final ByteAccess access )
+		{
+			super( access );
+		}
+
+		public void setAccess( final ByteAccess access )
+		{
+			dataAccess = access;
+		}
+	}
+
+	// this is the constructor if you want it to read from an array
+	public VolatileByteType( final NativeImg< ?, ? extends VolatileByteAccess > img )
+	{
+		super( new WrappedByteType( img ), false );
+		this.img = img;
+	}
+
+	// this is the constructor if you want to specify the dataAccess
+	public VolatileByteType( final VolatileByteAccess access )
+	{
+		super( new WrappedByteType( access ), access.isValid() );
+		this.img = null;
+	}
+
+	// this is the constructor if you want it to be a variable
+	public VolatileByteType( final int value )
+	{
+		this( new VolatileByteArray( 1, true ) );
+		set( value );
+	}
+
+	// this is the constructor if you want it to be a variable
+	public VolatileByteType()
+	{
+		this( 0 );
+	}
+
+	public void set( final int value )
+	{
+		get().setInteger( value );
+	}
+
+	@Override
+	public void updateContainer( final Object c )
+	{
+		final VolatileByteAccess a = img.update( c );
+		( ( WrappedByteType )t ).setAccess( a );
+		setValid( a.isValid() );
+	}
+
+	@Override
+	public NativeImg< VolatileByteType, ? extends VolatileByteAccess > createSuitableNativeImg( final NativeImgFactory< VolatileByteType > storageFactory, final long[] dim )
+	{
+		// create the container
+		@SuppressWarnings( "unchecked" )
+		final NativeImg< VolatileByteType, ? extends VolatileByteAccess > container = ( NativeImg< VolatileByteType, ? extends VolatileByteAccess > ) storageFactory.createByteInstance( dim, new Fraction() );
+
+		// create a Type that is linked to the container
+		final VolatileByteType linkedType = new VolatileByteType( container );
+
+		// pass it to the NativeContainer
+		container.setLinkedType( linkedType );
+
+		return container;
+	}
+
+	@Override
+	public VolatileByteType duplicateTypeOnSameNativeImg()
+	{
+		return new VolatileByteType( img );
+	}
+
+	@Override
+	public VolatileByteType createVariable()
+	{
+		return new VolatileByteType();
+	}
+
+	@Override
+	public VolatileByteType copy()
+	{
+		final VolatileByteType v = createVariable();
+		v.set( this );
+		return v;
+	}
+}


### PR DESCRIPTION
Hi,

I've finished adding the support for (some) imglib2 pixel types while saving/reading BDV's XML/HDF5. The HDF5 takes the pixel data as they are and saves them natively. For instance, no everything-to-GRAY16 conversion is happening when exporting into XML/HDF5, instead the code now attempts to save as is.

I needed to extend the XML format with just one keyword to mark what voxel type was used when creating the accompanied HDF5 file. When reading (old) XMLs that don't have it, UnsignedShortType is assumed, making it backward compatible.

There are corresponding changes in the bigdataviewer_fiji repo (also in the branch HDF5_nativeTypes_byVlado).

Cheers,
V.

