### PR TITLE
Fix exception when closing a view frame after adding a source.

### DIFF
--- a/src/main/java/bdv/tools/VisibilityAndGroupingDialog.java
+++ b/src/main/java/bdv/tools/VisibilityAndGroupingDialog.java
@@ -568,7 +568,9 @@ public class VisibilityAndGroupingDialog extends JDialog
 				if ( visibility.numSources() != numSources || visibility.numGroups() != numGroups )
 					recreateContent();
 
-				currentButtons.get( visibility.getCurrentGroup() ).setSelected( true );
+				if ( numGroups > 0  )
+					currentButtons.get( visibility.getCurrentGroup() ).setSelected( true );
+
 				for ( int g = 0; g < numGroups; ++g )
 					fusedBoxes.get( g ).setSelected( visibility.isGroupActive( g ) );
 


### PR DESCRIPTION
This bug occurs with `ViewerFrame`s created e.g. in Mastodon. It does not happen for `ViewerFrame`s opened with `BdvFunction.show()`.

If a source is appended to the viewerframe - e.g. the bounding-box source - it is not possible to close the viewframe without triggering the exception pasted below.

Somehow, when the frame is closing, the `VisibilityAndGroupingDialog` instance goes through the buttons list after it has been cleared and tries to set the selected state of one.

This ad-hoc fix simply checks that there is a button to set the state of before doing so.

To see this bug in action, check the branch 'bbox' of the trndy/mastodon-tracking artifact. Creating a bounding-box during the detection sequence wizard generates this bug.

``` java
Exception in thread "AWT-EventQueue-0" java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(Unknown Source)
	at java.util.ArrayList.get(Unknown Source)
	at bdv.tools.VisibilityAndGroupingDialog$GroupingPanel.update(VisibilityAndGroupingDialog.java:572)
	at bdv.tools.VisibilityAndGroupingDialog$GroupingPanel.visibilityChanged(VisibilityAndGroupingDialog.java:607)
	at bdv.viewer.VisibilityAndGrouping.update(VisibilityAndGrouping.java:375)
	at bdv.viewer.ViewerPanel.removeSource(ViewerPanel.java:370)
	at bdv.tools.boundingbox.TransformedBoxOverlaySource.removeFromViewer(TransformedBoxOverlaySource.java:120)
	at bdv.tools.boundingbox.TransformedBoxEditor.uninstall(TransformedBoxEditor.java:180)
	at org.mastodon.trackmate.ui.wizard.descriptors.BoundingBoxDescriptor.uninstall(BoundingBoxDescriptor.java:80)
	at org.mastodon.trackmate.ui.wizard.descriptors.BoundingBoxDescriptor.access$3(BoundingBoxDescriptor.java:77)
	at org.mastodon.trackmate.ui.wizard.descriptors.BoundingBoxDescriptor$1.windowClosing(BoundingBoxDescriptor.java:185)
	at java.awt.AWTEventMulticaster.windowClosing(Unknown Source)
	at java.awt.AWTEventMulticaster.windowClosing(Unknown Source)
	at java.awt.Window.processWindowEvent(Unknown Source)
	at javax.swing.JFrame.processWindowEvent(Unknown Source)
	at java.awt.Window.processEvent(Unknown Source)
	at java.awt.Component.dispatchEventImpl(Unknown Source)
	at java.awt.Container.dispatchEventImpl(Unknown Source)
	at java.awt.Window.dispatchEventImpl(Unknown Source)
	at java.awt.Component.dispatchEvent(Unknown Source)
	at java.awt.EventQueue.dispatchEventImpl(Unknown Source)
	at java.awt.EventQueue.access$500(Unknown Source)
	at java.awt.EventQueue$3.run(Unknown Source)
	at java.awt.EventQueue$3.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.awt.EventQueue$4.run(Unknown Source)
	at java.awt.EventQueue$4.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.awt.EventQueue.dispatchEvent(Unknown Source)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
	at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
	at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.awt.EventDispatchThread.run(Unknown Source)
```