### PR TITLE
Fix determining best mipmap level for non-isotropic data

### DIFF
--- a/src/main/java/bdv/export/ProposeMipmaps.java
+++ b/src/main/java/bdv/export/ProposeMipmaps.java
@@ -162,7 +162,7 @@ public class ProposeMipmaps
 	}
 
 	/**
-	 * Adjust voxelSize such that the largest dimension is 1.0
+	 * Adjust voxelSize such that the smallest dimension is 1.0
 	 *
 	 * @param size
 	 */

--- a/src/main/java/bdv/util/MipmapTransforms.java
+++ b/src/main/java/bdv/util/MipmapTransforms.java
@@ -29,8 +29,8 @@
  */
 package bdv.util;
 
-import java.util.Arrays;
-
+import bdv.export.ProposeMipmaps;
+import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.util.LinAlgHelpers;
 import bdv.viewer.Source;
@@ -82,47 +82,38 @@ public class MipmapTransforms
 	 */
 	public static double getVoxelScreenSize( final AffineTransform3D screenTransform, final Source< ? > source, final int timepoint, final int mipmapIndex )
 	{
-		final double[] voxelScreenSizes = getVoxelScreenSizes( screenTransform, source, timepoint, mipmapIndex );
-		return Arrays.stream( voxelScreenSizes ).max().getAsDouble();
-	}
-
-	/**
-	 * Compute the projected voxel size at the given screen transform and mipmap
-	 * level of a {@link Source}. Take a source voxel (0,0,0)-(1,1,1) at the
-	 * given mipmap level and transform it to the screen image at the given
-	 * screen scale.
-	 *
-	 * @param screenTransform
-	 *            transforms screen coordinates to global coordinates.
-	 * @param source
-	 *            the source
-	 * @param timepoint
-	 *            for which timepoint to query the source
-	 * @param mipmapIndex
-	 *            mipmap level
-	 * @return pixel size
-	 */
-	public static double[] getVoxelScreenSizes( final AffineTransform3D screenTransform, final Source< ? > source, final int timepoint, final int mipmapIndex )
-	{
-		final double[] pixelSize = new double[ 3 ];
+		double pixelSize = 0;
 		final AffineTransform3D sourceToScreen = new AffineTransform3D();
 		sourceToScreen.set( screenTransform );
 		final AffineTransform3D sourceTransform = new AffineTransform3D();
 		source.getSourceTransform( timepoint, mipmapIndex, sourceTransform );
 		sourceToScreen.concatenate( sourceTransform );
+
+		final VoxelDimensions voxelDimensions = source.getVoxelDimensions();
+		final double[] normalizedVoxelSize = new double[] { 1, 1, 1 };
+		if ( voxelDimensions != null )
+		{
+			voxelDimensions.dimensions( normalizedVoxelSize );
+			ProposeMipmaps.normalizeVoxelSize( normalizedVoxelSize );
+		}
+
 		final double[] zero = new double[] { 0, 0, 0 };
 		final double[] tzero = new double[ 3 ];
 		final double[] one = new double[ 3 ];
 		final double[] tone = new double[ 3 ];
-		final double[] diff = new double[ 3 ];
+		final double[] diff = new double[ 2 ];
 		sourceToScreen.apply( zero, tzero );
 		for ( int i = 0; i < 3; ++i )
 		{
 			for ( int d = 0; d < 3; ++d )
-				one[ d ] = d == i ? 1 : 0;
+				one[ d ] = d == i ? 1 / normalizedVoxelSize[ d ] : 0;
 			sourceToScreen.apply( one, tone );
-			LinAlgHelpers.subtract( tone, tzero, diff );
-			pixelSize[ i ] = LinAlgHelpers.length( diff );
+			LinAlgHelpers.subtract( tone, tzero, tone );
+			diff[0] = tone[0];
+			diff[1] = tone[1];
+			final double l = LinAlgHelpers.length( diff );
+			if ( l > pixelSize )
+				pixelSize = l;
 		}
 		return pixelSize;
 	}
@@ -142,30 +133,20 @@ public class MipmapTransforms
 	 */
 	public static int getBestMipMapLevel( final AffineTransform3D screenTransform, final Source< ? > source, final int timepoint )
 	{
-		final int[] targetLevels = new int[] { -1, -1, -1 };
-		final int numLevels = source.getNumMipmapLevels();
-		for ( int level = numLevels - 1; level >= 0; --level )
+		int targetLevel = source.getNumMipmapLevels() - 1;
+		for ( int level = targetLevel - 1; level >= 0; level-- )
 		{
-			final double[] voxelScreenSizes = getVoxelScreenSizes( screenTransform, source, timepoint, level );
-			for ( int d = 0; d < 3; ++d )
-			{
-				if ( targetLevels[ d ] == -1 && voxelScreenSizes[ d ] < 0.99 /* 1.0 */ )
-				{
-					targetLevels[ d ] = level;
-				}
-			}
+			if ( getVoxelScreenSize( screenTransform, source, timepoint, level ) >= 0.99 /* 1.0 */)
+				targetLevel = level;
+			else
+				break;
 		}
-		int targetLevel = Arrays.stream( targetLevels ).max().getAsInt();
-		if ( targetLevel == -1 )
+		if ( targetLevel > 0 )
 		{
-			targetLevel = 0;
-		}
-		else if ( targetLevel < numLevels - 1 )
-		{
-			final double size1 = getVoxelScreenSize( screenTransform, source, timepoint, targetLevel + 1 );
-			final double size0 = getVoxelScreenSize( screenTransform, source, timepoint, targetLevel );
-			if ( Math.abs( size1 - 1.0 ) / 2 < Math.abs( size0 - 1.0 ) )
-				++targetLevel;
+			final double size1 = getVoxelScreenSize( screenTransform, source, timepoint, targetLevel );
+			final double size0 = getVoxelScreenSize( screenTransform, source, timepoint, targetLevel - 1 );
+			if ( Math.abs( size1 - 1.0 ) / 2 > Math.abs( size0 - 1.0 ) )
+				targetLevel--;
 		}
 		return targetLevel;
 	}


### PR DESCRIPTION
I ran into what I believe is an incorrect behavior of `getBestMipMapLevel()` when visualizing non-isotropic data. In my case the pixel resolution is 4x4x40nm, and the downsampling factors for the mipmaps are:
```
0: [1,1,1]
1: [2,2,1]
2: [4,4,1]
3: [8,8,1]
4: [16,16,2] 
```

Determining the best mipmap level works properly in orthogonal XY view, but the problem occurs when the view is rotated (especially in orthogonal XZ or ZY views). Due to the same Z scaling factor in the first 4 levels, it picks either scale level 4 when zooming out a lot, or scale level 0 when zooming closer. Sometimes it picks scale level 3 over scale level 4 because of [this heuristic](https://github.com/bigdataviewer/bigdataviewer-core/blob/b60e6079c592f0523a3315099d5c34330e0e78ae/src/main/java/bdv/util/MipmapTransforms.java#L133-L139), but it entirely skips scale levels 1 and 2.

This happens because the contribution of the Z component to the displayed voxel size is the same for the first 4 scale levels in this example, so it always dominates the selection.
The fix is to compute displayed voxel size and best mipmap level separately for each dimension.


## Demo (XZ view, 1:1:10 resolution)

**Old behavior:**

![old-behavior](https://user-images.githubusercontent.com/6253116/54787442-1c4d8a00-4c02-11e9-9412-c032d06c1ec0.gif)


**New behavior:**

![new-behavior](https://user-images.githubusercontent.com/6253116/54787455-21aad480-4c02-11e9-9472-93609b5a9d4a.gif)
