### PR TITLE
Add `next()` method to Interpolation enum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,5 +193,11 @@
 			<artifactId>scijava-listeners</artifactId>
 			<version>1.0.0-beta-2</version>
 		</dependency>
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/bdv/viewer/Interpolation.java
+++ b/src/main/java/bdv/viewer/Interpolation.java
@@ -37,7 +37,14 @@ public enum Interpolation
 	NEARESTNEIGHBOR( "nearest-neighbor interpolation" ),
 	NLINEAR( "tri-linear interpolation" );
 
+	static {
+		NEARESTNEIGHBOR.next = NLINEAR;
+		NLINEAR.next = NEARESTNEIGHBOR;
+	}
+
 	private final String name;
+
+	private Interpolation next = null;
 
 	private Interpolation( final String name )
 	{
@@ -47,5 +54,9 @@ public enum Interpolation
 	public String getName()
 	{
 		return name;
+	}
+
+	public Interpolation next() {
+		return next;
 	}
 }

--- a/src/main/java/bdv/viewer/Interpolation.java
+++ b/src/main/java/bdv/viewer/Interpolation.java
@@ -37,14 +37,7 @@ public enum Interpolation
 	NEARESTNEIGHBOR( "nearest-neighbor interpolation" ),
 	NLINEAR( "tri-linear interpolation" );
 
-	static {
-		NEARESTNEIGHBOR.next = NLINEAR;
-		NLINEAR.next = NEARESTNEIGHBOR;
-	}
-
 	private final String name;
-
-	private Interpolation next = null;
 
 	private Interpolation( final String name )
 	{
@@ -57,6 +50,6 @@ public enum Interpolation
 	}
 
 	public Interpolation next() {
-		return next;
+		return Interpolation.values()[ ( this.ordinal() + 1 ) % Interpolation.values().length ];
 	}
 }

--- a/src/main/java/bdv/viewer/Interpolation.java
+++ b/src/main/java/bdv/viewer/Interpolation.java
@@ -49,6 +49,13 @@ public enum Interpolation
 		return name;
 	}
 
+	/**
+	 *
+	 * @return The next {@link Interpolation} value in the order defined by
+	 * {@link Interpolation#values()} with cyclic continuation: The last element
+	 * returns the first element. Can be used to toggle/cycle through interpolations
+	 * in graphical user interface.
+	 */
 	public Interpolation next() {
 		return Interpolation.values()[ ( this.ordinal() + 1 ) % Interpolation.values().length ];
 	}

--- a/src/test/java/bdv/viewer/InterpolationTest.java
+++ b/src/test/java/bdv/viewer/InterpolationTest.java
@@ -1,0 +1,15 @@
+package bdv.viewer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class InterpolationTest {
+
+    @Test
+    public void next() {
+        Assert.assertEquals( Interpolation.NLINEAR, Interpolation.NEARESTNEIGHBOR.next() );
+        Assert.assertEquals( Interpolation.NEARESTNEIGHBOR, Interpolation.NLINEAR.next() );
+    }
+}


### PR DESCRIPTION
Toggling interpolation now simply becomes `interpolation.next()` instead of `NLINEAR.equals(interpolation) ? NEARESTNEIGHBOR : NLINEAR`.

@tpietzsch If this is something that you would like, I will add a short doc string with an explanation before this gets merged.