### PR TITLE
SourceGroupEditor: Fix bug in Linux when editing group name

### DIFF
--- a/src/main/java/bdv/ui/sourcegrouptree/SourceGroupEditor.java
+++ b/src/main/java/bdv/ui/sourcegrouptree/SourceGroupEditor.java
@@ -1,5 +1,8 @@
 package bdv.ui.sourcegrouptree;
 
+import java.awt.Component;
+import java.awt.Graphics;
+import javax.swing.Icon;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellEditor;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -27,7 +30,32 @@ class SourceGroupEditor extends DefaultTreeCellEditor
 	@Override
 	protected void determineOffset( final JTree tree, final Object value, final boolean isSelected, final boolean expanded, final boolean leaf, final int row )
 	{
-		super.determineOffset(tree, value, isSelected, expanded, leaf, row);
+		editingIcon = emptyIcon;
 		offset = sourceGroupRenderer.determineOffset( value );
 	}
+
+	private final Icon emptyIcon = new Icon()
+	{
+		private int iconHeight = -1;
+
+		@Override
+		public void paintIcon( final Component c, final Graphics g, final int x, final int y )
+		{
+		}
+
+		@Override
+		public int getIconWidth()
+		{
+			return 1;
+		}
+
+		@Override
+		public int getIconHeight()
+		{
+			if ( iconHeight < 0 && renderer != null )
+				iconHeight = renderer.getDefaultLeafIcon().getIconHeight();
+			return iconHeight < 0 ? 1 : iconHeight;
+		}
+	};
+
 }

--- a/src/main/java/bdv/ui/sourcegrouptree/SourceGroupEditor.java
+++ b/src/main/java/bdv/ui/sourcegrouptree/SourceGroupEditor.java
@@ -27,7 +27,7 @@ class SourceGroupEditor extends DefaultTreeCellEditor
 	@Override
 	protected void determineOffset( final JTree tree, final Object value, final boolean isSelected, final boolean expanded, final boolean leaf, final int row )
 	{
-		editingIcon = null;
+		super.determineOffset(tree, value, isSelected, expanded, leaf, row);
 		offset = sourceGroupRenderer.determineOffset( value );
 	}
 }


### PR DESCRIPTION
* setting no `editingIcon` when in edit mode makes the group name disappear on Linux
* this fix adds a call to the default `determineOffset` method (where the icon is set)

@tpietzsch Let me know if I should look for an alternative solution.