### PR TITLE
Pass List<SourceAndConverter> instead of List<Source> to AccumulatePr…

### DIFF
--- a/src/main/java/bdv/viewer/render/AccumulateProjectorARGB.java
+++ b/src/main/java/bdv/viewer/render/AccumulateProjectorARGB.java
@@ -29,10 +29,9 @@
  */
 package bdv.viewer.render;
 
+import bdv.viewer.SourceAndConverter;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
-
-import bdv.viewer.Source;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -43,15 +42,15 @@ public class AccumulateProjectorARGB extends AccumulateProjector< ARGBType, ARGB
 	public static AccumulateProjectorFactory< ARGBType > factory = new AccumulateProjectorFactory< ARGBType >()
 	{
 		@Override
-		public AccumulateProjectorARGB createAccumulateProjector(
+		public AccumulateProjectorARGB createProjector(
 				final ArrayList< VolatileProjector > sourceProjectors,
-				final ArrayList< Source< ? > > sources,
+				final ArrayList< SourceAndConverter< ? > > sources,
 				final ArrayList< ? extends RandomAccessible< ? extends ARGBType > > sourceScreenImages,
-				final RandomAccessibleInterval< ARGBType > targetScreenImages,
+				final RandomAccessibleInterval< ARGBType > targetScreenImage,
 				final int numThreads,
 				final ExecutorService executorService )
 		{
-			return new AccumulateProjectorARGB( sourceProjectors, sourceScreenImages, targetScreenImages, numThreads, executorService );
+			return new AccumulateProjectorARGB( sourceProjectors, sourceScreenImages, targetScreenImage, numThreads, executorService );
 		}
 	};
 

--- a/src/main/java/bdv/viewer/render/AccumulateProjectorFactory.java
+++ b/src/main/java/bdv/viewer/render/AccumulateProjectorFactory.java
@@ -29,6 +29,7 @@
  */
 package bdv.viewer.render;
 
+import bdv.viewer.SourceAndConverter;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
 
@@ -53,11 +54,46 @@ public interface AccumulateProjectorFactory< A >
 	 * @param executorService
 	 *            {@link ExecutorService} to use for rendering. may be null.
 	 */
-	public VolatileProjector createAccumulateProjector(
+	default VolatileProjector createProjector(
+			final ArrayList< VolatileProjector > sourceProjectors,
+			final ArrayList< SourceAndConverter< ? > > sources,
+			final ArrayList< ? extends RandomAccessible< ? extends A > > sourceScreenImages,
+			final RandomAccessibleInterval< A > targetScreenImage,
+			final int numThreads,
+			final ExecutorService executorService )
+	{
+		final ArrayList< Source< ? > > spimSources = new ArrayList<>();
+		for ( SourceAndConverter< ? > source : sources )
+			spimSources.add( source.getSpimSource() );
+		return createAccumulateProjector( sourceProjectors, spimSources, sourceScreenImages, targetScreenImage, numThreads, executorService );
+	}
+
+	/**
+	 * @deprecated Use {@link #createProjector(ArrayList, ArrayList, ArrayList, RandomAccessibleInterval, int, ExecutorService)} instead.
+	 *
+	 * @param sourceProjectors
+	 *            projectors that will be used to render {@code sources}.
+	 * @param sources
+	 *            sources to identify which channels are being rendered
+	 * @param sourceScreenImages
+	 *            rendered images that will be accumulated into
+	 *            {@code target}.
+	 * @param targetScreenImage
+	 *            final image to render.
+	 * @param numThreads
+	 *            how many threads to use for rendering.
+	 * @param executorService
+	 *            {@link ExecutorService} to use for rendering. may be null.
+	 */
+	@Deprecated
+	default VolatileProjector createAccumulateProjector(
 			final ArrayList< VolatileProjector > sourceProjectors,
 			final ArrayList< Source< ? > > sources,
 			final ArrayList< ? extends RandomAccessible< ? extends A > > sourceScreenImages,
 			final RandomAccessibleInterval< A > targetScreenImage,
 			final int numThreads,
-			final ExecutorService executorService );
+			final ExecutorService executorService )
+	{
+		throw new UnsupportedOperationException( "AccumulateProjectorFactory::createAccumulateProjector is deprecated and by default not implemented" );
+	}
 }

--- a/src/main/java/bdv/viewer/render/MultiResolutionRenderer.java
+++ b/src/main/java/bdv/viewer/render/MultiResolutionRenderer.java
@@ -29,6 +29,7 @@
  */
 package bdv.viewer.render;
 
+import bdv.viewer.SourceAndConverter;
 import java.awt.image.BufferedImage;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -654,7 +655,7 @@ public class MultiResolutionRenderer
 		{
 			final ArrayList< VolatileProjector > sourceProjectors = new ArrayList<>();
 			final ArrayList< ARGBScreenImage > sourceImages = new ArrayList<>();
-			final ArrayList< Source< ? > > sources = new ArrayList<>();
+			final ArrayList< SourceAndConverter< ? > > sources = new ArrayList<>();
 			int j = 0;
 			for ( final int i : visibleSourceIndices )
 			{
@@ -665,10 +666,10 @@ public class MultiResolutionRenderer
 						viewerState, sourceStates.get( i ), i, currentScreenScaleIndex,
 						renderImage, maskArray );
 				sourceProjectors.add( p );
-				sources.add( sourceStates.get( i ).getSpimSource() );
+				sources.add( sourceStates.get( i ).getHandle() );
 				sourceImages.add( renderImage );
 			}
-			projector = accumulateProjectorFactory.createAccumulateProjector( sourceProjectors, sources, sourceImages, screenImage, numRenderingThreads, renderingExecutorService );
+			projector = accumulateProjectorFactory.createProjector( sourceProjectors, sources, sourceImages, screenImage, numRenderingThreads, renderingExecutorService );
 		}
 		previousTimepoint = viewerState.getCurrentTimepoint();
 		viewerState.getViewerTransform( currentProjectorTransform );

--- a/src/main/java/bdv/viewer/state/SourceState.java
+++ b/src/main/java/bdv/viewer/state/SourceState.java
@@ -149,5 +149,14 @@ public class SourceState< T > extends SourceAndConverter< T >
 	{
 		return volatileSourceState;
 	}
+
+	/**
+	 * Get the SourceAndConverter that this SourceState represents.
+	 * This handle is used to make modifications to the {@link bdv.viewer.ViewerState}
+	 */
+	public SourceAndConverter< ? > getHandle()
+	{
+		return handle;
+	}
 }
 


### PR DESCRIPTION
…ojectorFactory

The new variant of the method is named "createProjector" instead of
"createAccumulateProjector" because it has the same erasure.
The default implementation of "createProjector" forwared to the
(deprecated) "createAccumulateProjector", so existing AccumulateProjectorFactory
implementations should keep working.