### PR TITLE
Fix a bug in proposeMipMaps.

### DIFF
--- a/src/main/java/bdv/export/ProposeMipmaps.java
+++ b/src/main/java/bdv/export/ProposeMipmaps.java
@@ -240,7 +240,7 @@ public class ProposeMipmaps
 		final double[] numBits = new double[ n ];
 		Arrays.setAll( numBits, d -> Math.log( m * shape[ d ] ) / Math.log( 2 ) );
 		final int[] intNumBits = new int[ n ];
-		Arrays.setAll( intNumBits, d -> ( int ) numBits[ d ] );
+		Arrays.setAll( intNumBits, d -> Math.max( 0, ( int ) numBits[ d ] ) );
 		for ( int sumIntNumBits = Arrays.stream( intNumBits ).sum(); sumIntNumBits + 1 <= sumNumBits; ++sumIntNumBits )
 		{
 			double maxDiff = 0;


### PR DESCRIPTION
If numBits turns negative, it suggests completely wrong blocksizes, example below:

final ViewSetup setup = new ViewSetup( 0, "0", new FinalDimensions( 2048, 2048, 1 ), new FinalVoxelDimensions( "um", 0.004488999829630086, 0.004488999829630086, 1.0 ), null, null, null, null );
final ExportMipmapInfo e = ProposeMipmaps.proposeMipmaps( setup );

for ( int l = 0; l < e.getNumLevels(); ++l )
	System.out.println( Util.printCoordinates( e.getSubdivisions()[l]  ) );

/*
Yields:

(128, 64, -2147483648)
(64, 64, 1)
(64, 64, 1)
(64, 32, 2)

With fix:
(64, 64, 1)
(64, 64, 1)
(64, 64, 1)
(64, 32, 2)
 */