### PR TITLE
SourceAndConverter and Source are org.scijava.Named objects.

### DIFF
--- a/src/main/java/bdv/AbstractSpimSource.java
+++ b/src/main/java/bdv/AbstractSpimSource.java
@@ -118,7 +118,7 @@ public abstract class AbstractSpimSource< T extends NumericType< T > > implement
 
 	protected final int setupId;
 
-	protected final String name;
+	protected String name;
 
 	protected final List< TimePoint > timePointsOrdered;
 
@@ -260,6 +260,9 @@ public abstract class AbstractSpimSource< T extends NumericType< T > > implement
 	{
 		return name;
 	}
+
+	@Override
+	public void setName(String name) { this.name = name; }
 
 	@Override
 	public VoxelDimensions getVoxelDimensions()

--- a/src/main/java/bdv/tools/boundingbox/TransformedBoxPlaceHolderSource.java
+++ b/src/main/java/bdv/tools/boundingbox/TransformedBoxPlaceHolderSource.java
@@ -55,7 +55,7 @@ final class TransformedBoxPlaceHolderSource implements Source< Void >
 {
 	private final UnsignedShortType type = new UnsignedShortType();
 
-	private final String name;
+	private String name;
 
 	private final TransformedBox bbSource;
 
@@ -76,6 +76,9 @@ final class TransformedBoxPlaceHolderSource implements Source< Void >
 	{
 		return name;
 	}
+
+	@Override
+	public void setName(String name) { this.name = name; }
 
 	@Override
 	public VoxelDimensions getVoxelDimensions()

--- a/src/main/java/bdv/tools/transformation/TransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/TransformedSource.java
@@ -238,6 +238,9 @@ public class TransformedSource< T > implements Source< T >, MipmapOrdering
 	}
 
 	@Override
+	public void setName(String name) { source.setName(name); } // or throw unsupportedoperationexception () ?
+
+	@Override
 	public VoxelDimensions getVoxelDimensions()
 	{
 		return source.getVoxelDimensions();

--- a/src/main/java/bdv/util/RealRandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleSource.java
@@ -54,7 +54,7 @@ public abstract class RealRandomAccessibleSource< T extends Type< T > > implemen
 
 	protected final T type;
 
-	protected final String name;
+	protected String name;
 
 	protected final VoxelDimensions voxelDimensions;
 
@@ -114,6 +114,9 @@ public abstract class RealRandomAccessibleSource< T extends Type< T > > implemen
 	{
 		return name;
 	}
+
+	@Override
+	public void setName(String name) { this.name = name; }
 
 	@Override
 	public VoxelDimensions getVoxelDimensions()

--- a/src/main/java/bdv/viewer/Source.java
+++ b/src/main/java/bdv/viewer/Source.java
@@ -36,6 +36,7 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
+import org.scijava.Named;
 
 /**
  * Provides image data for all timepoints of one view setup.
@@ -47,7 +48,7 @@ import net.imglib2.realtransform.AffineTransform3D;
  *
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
-public interface Source< T >
+public interface Source< T > extends Named
 {
 	/**
 	 * Is there a stack at timepoint index t?
@@ -116,6 +117,11 @@ public interface Source< T >
 	 * @return the name of the source.
 	 */
 	public String getName();
+
+	// TODO FOR COMPATIBILITY ? Remove or not ?
+	public default void setName(String name) {
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Get voxel size and unit for this source. May return null.

--- a/src/main/java/bdv/viewer/SourceAndConverter.java
+++ b/src/main/java/bdv/viewer/SourceAndConverter.java
@@ -32,11 +32,12 @@ package bdv.viewer;
 import net.imglib2.Volatile;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.ARGBType;
+import org.scijava.Named;
 
 /**
  * Data source (for one view setup) and a converter to ARGBType.
  */
-public class SourceAndConverter< T >
+public class SourceAndConverter< T > implements Named
 {
 	/**
 	 * provides image data for all timepoints of one view.
@@ -50,11 +51,17 @@ public class SourceAndConverter< T >
 
 	protected final SourceAndConverter< ? extends Volatile< T > > volatileSourceAndConverter;
 
+	/**
+	 * Name of the SourceAndConverter
+	 */
+	protected String name;
+
 	public SourceAndConverter( final Source< T > spimSource, final Converter< T, ARGBType > converter )
 	{
 		this.spimSource = spimSource;
 		this.converter = converter;
 		this.volatileSourceAndConverter = null;
+		this.name = spimSource.getName();
 	}
 
 	public SourceAndConverter( final Source< T > spimSource, final Converter< T, ARGBType > converter, final SourceAndConverter< ? extends Volatile< T > > volatileSourceAndConverter )
@@ -62,6 +69,7 @@ public class SourceAndConverter< T >
 		this.spimSource = spimSource;
 		this.converter = converter;
 		this.volatileSourceAndConverter = volatileSourceAndConverter;
+		this.name = spimSource.getName();
 	}
 
 	/**
@@ -73,6 +81,7 @@ public class SourceAndConverter< T >
 		this.spimSource = soc.spimSource;
 		this.converter = soc.converter;
 		this.volatileSourceAndConverter = soc.volatileSourceAndConverter;
+		this.name = soc.getName();
 	}
 
 	/**
@@ -96,5 +105,22 @@ public class SourceAndConverter< T >
 	public SourceAndConverter< ? extends Volatile< T > > asVolatile()
 	{
 		return volatileSourceAndConverter;
+	}
+
+	/**
+	 * @return the name of the {@link SourceAndConverter}
+	 */
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Sets the new name of the {@link SourceAndConverter}
+	 * @param name
+	 */
+	@Override
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/src/test/java/bdv/ui/CreateViewerState.java
+++ b/src/test/java/bdv/ui/CreateViewerState.java
@@ -32,7 +32,7 @@ public class CreateViewerState
 			return "source(" + id.getAndIncrement() + ")";
 		}
 
-		private final String name;
+		private String name;
 
 		private final IntPredicate isPresent;
 
@@ -77,6 +77,9 @@ public class CreateViewerState
 		{
 			return name;
 		}
+
+		@Override
+		public void setName(String name) { this.name = name; }
 
 		@Override
 		public VoxelDimensions getVoxelDimensions()

--- a/src/test/java/bdv/viewer/BasicViewerStateTest.java
+++ b/src/test/java/bdv/viewer/BasicViewerStateTest.java
@@ -302,7 +302,7 @@ public class BasicViewerStateTest
 			return "source(" + id.getAndIncrement() + ")";
 		}
 
-		private final String name;
+		private String name;
 
 		private final IntPredicate isPresent;
 
@@ -338,6 +338,9 @@ public class BasicViewerStateTest
 		{
 			return name;
 		}
+
+		@Override
+		public void setName(String name) { this.name = name; }
 
 		@Override
 		public VoxelDimensions getVoxelDimensions()


### PR DESCRIPTION
This means the names are not final anymore. Is this acceptable ?

By default `SourceAndConverter` objects take the name of the associated `SpimSource` given in the constructor, or duplicate the name if the constructor called is the one which needs a `SourceAndConverter` as an input. This initial `SourceAndConverter` name can be changed by using the method `SourceAndConverter::setName`.

There is a default `setName` method which throws an exception in the `Source` interface.

As source names are not final, there's a risk to loose synchronization with the display in the bigdataviewer UI.