### PR TITLE
Important: Fix memory leak

### DIFF
--- a/src/main/java/net/imglib2/display/RealARGBColorConverter.java
+++ b/src/main/java/net/imglib2/display/RealARGBColorConverter.java
@@ -57,7 +57,7 @@ class Instances
 					provider = new ClassCopyProvider<>( Imp.class, RealARGBColorConverter.class, double.class, double.class );
 			}
 		}
-		return provider.newInstanceForKey( type, min, max );
+		return provider.newInstanceForKey( type.getClass(), min, max );
 	}
 
 	public static class Imp< R extends RealType< ? > > implements RealARGBColorConverter< R >


### PR DESCRIPTION
`ClassCopyProvider` is used to create `RealARGBColorConverter`. Unfortunately an imglib2 pixel is used as the key. ClassCopyProvider keeps the key (imglib2 pixel) in memory. The pixel holds a reference to the image. Hence prevents the image from being garbage collected.

This can prevent many images shown in BDV from being garbage collected. As every new pixel value is a new key, and will kept.