### PR TITLE
BehaviourTransformEventHandler3D: fix dead lock.

### DIFF
--- a/src/main/java/bdv/BehaviourTransformEventHandler3D.java
+++ b/src/main/java/bdv/BehaviourTransformEventHandler3D.java
@@ -198,8 +198,8 @@ public class BehaviourTransformEventHandler3D implements BehaviourTransformEvent
 				affine.scale( ( double ) width / canvasW );
 				affine.set( affine.get( 0, 3 ) + width / 2, 0, 3 );
 				affine.set( affine.get( 1, 3 ) + height / 2, 1, 3 );
-				notifyListener();
 			}
+			notifyListener();
 		}
 		canvasW = width;
 		canvasH = height;


### PR DESCRIPTION
This fixes a deadlock, where one of the listeners wants to sync on
ViewerPanel, while an other thread that has a lock on ViewerPanel wants to
sync on the viewer transform.

The deadlock was cause by this loop:
```java
for ( int i = 0; i < 60; i++ )
	BdvFunctions.show( ArrayImgs.bytes( 10, 10 ), "image" ).close();
```