### PR TITLE
Fix Big Data Viewer Garbage Collection

### DIFF
--- a/src/main/java/bdv/tools/HelpDialog.java
+++ b/src/main/java/bdv/tools/HelpDialog.java
@@ -28,7 +28,7 @@
  */
 package bdv.tools;
 
-import bdv.util.MemoryFixedDialog;
+import bdv.util.DelayedPackDialog;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -48,9 +48,8 @@ import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
-import javax.swing.WindowConstants;
 
-public class HelpDialog extends MemoryFixedDialog
+public class HelpDialog extends DelayedPackDialog
 {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/bdv/tools/HelpDialog.java
+++ b/src/main/java/bdv/tools/HelpDialog.java
@@ -28,6 +28,8 @@
  */
 package bdv.tools;
 
+import bdv.util.MemoryFixedDialog;
+
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -42,14 +44,13 @@ import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
 import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.WindowConstants;
 
-public class HelpDialog extends JDialog
+public class HelpDialog extends MemoryFixedDialog
 {
 	private static final long serialVersionUID = 1L;
 
@@ -100,7 +101,6 @@ public class HelpDialog extends JDialog
 			am.put( hideKey, hideAction );
 
 			pack();
-			setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 		}
 		catch ( final IOException e )
 		{

--- a/src/main/java/bdv/tools/RecordMaxProjectionDialog.java
+++ b/src/main/java/bdv/tools/RecordMaxProjectionDialog.java
@@ -30,7 +30,7 @@ package bdv.tools;
 
 import bdv.cache.CacheControl;
 import bdv.export.ProgressWriter;
-import bdv.util.MemoryFixedDialog;
+import bdv.util.DelayedPackDialog;
 import bdv.util.Prefs;
 import bdv.viewer.BasicViewerState;
 import bdv.viewer.ViewerPanel;
@@ -64,7 +64,6 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
-import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import net.imglib2.Cursor;
@@ -77,7 +76,7 @@ import bdv.viewer.OverlayRenderer;
 import bdv.viewer.render.RenderTarget;
 import net.imglib2.util.LinAlgHelpers;
 
-public class RecordMaxProjectionDialog extends MemoryFixedDialog implements OverlayRenderer
+public class RecordMaxProjectionDialog extends DelayedPackDialog implements OverlayRenderer
 {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/bdv/tools/RecordMaxProjectionDialog.java
+++ b/src/main/java/bdv/tools/RecordMaxProjectionDialog.java
@@ -30,6 +30,7 @@ package bdv.tools;
 
 import bdv.cache.CacheControl;
 import bdv.export.ProgressWriter;
+import bdv.util.MemoryFixedDialog;
 import bdv.util.Prefs;
 import bdv.viewer.BasicViewerState;
 import bdv.viewer.ViewerPanel;
@@ -56,7 +57,6 @@ import javax.swing.BoxLayout;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -77,7 +77,7 @@ import bdv.viewer.OverlayRenderer;
 import bdv.viewer.render.RenderTarget;
 import net.imglib2.util.LinAlgHelpers;
 
-public class RecordMaxProjectionDialog extends JDialog implements OverlayRenderer
+public class RecordMaxProjectionDialog extends MemoryFixedDialog implements OverlayRenderer
 {
 	private static final long serialVersionUID = 1L;
 
@@ -275,7 +275,6 @@ public class RecordMaxProjectionDialog extends JDialog implements OverlayRendere
 		am.put( hideKey, hideAction );
 
 		pack();
-		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 	}
 
 	/**

--- a/src/main/java/bdv/tools/RecordMovieDialog.java
+++ b/src/main/java/bdv/tools/RecordMovieDialog.java
@@ -30,7 +30,7 @@ package bdv.tools;
 
 import bdv.cache.CacheControl;
 import bdv.export.ProgressWriter;
-import bdv.util.MemoryFixedDialog;
+import bdv.util.DelayedPackDialog;
 import bdv.util.Prefs;
 import bdv.viewer.BasicViewerState;
 import bdv.viewer.ViewerPanel;
@@ -63,14 +63,13 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
-import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import net.imglib2.realtransform.AffineTransform3D;
 import bdv.viewer.OverlayRenderer;
 import bdv.viewer.render.RenderTarget;
 
-public class RecordMovieDialog extends MemoryFixedDialog implements OverlayRenderer
+public class RecordMovieDialog extends DelayedPackDialog implements OverlayRenderer
 {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/bdv/tools/RecordMovieDialog.java
+++ b/src/main/java/bdv/tools/RecordMovieDialog.java
@@ -30,6 +30,7 @@ package bdv.tools;
 
 import bdv.cache.CacheControl;
 import bdv.export.ProgressWriter;
+import bdv.util.MemoryFixedDialog;
 import bdv.util.Prefs;
 import bdv.viewer.BasicViewerState;
 import bdv.viewer.ViewerPanel;
@@ -55,7 +56,6 @@ import javax.swing.BoxLayout;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -70,7 +70,7 @@ import net.imglib2.realtransform.AffineTransform3D;
 import bdv.viewer.OverlayRenderer;
 import bdv.viewer.render.RenderTarget;
 
-public class RecordMovieDialog extends JDialog implements OverlayRenderer
+public class RecordMovieDialog extends MemoryFixedDialog implements OverlayRenderer
 {
 	private static final long serialVersionUID = 1L;
 
@@ -248,7 +248,6 @@ public class RecordMovieDialog extends JDialog implements OverlayRenderer
 		am.put( hideKey, hideAction );
 
 		pack();
-		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 	}
 
 	public void recordMovie( final int width, final int height, final int minTimepointIndex, final int maxTimepointIndex, final File dir ) throws IOException

--- a/src/main/java/bdv/tools/VisibilityAndGroupingDialog.java
+++ b/src/main/java/bdv/tools/VisibilityAndGroupingDialog.java
@@ -28,6 +28,7 @@
  */
 package bdv.tools;
 
+import bdv.util.MemoryFixedDialog;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerState;
 import bdv.viewer.VisibilityAndGrouping;
@@ -61,7 +62,6 @@ import javax.swing.ButtonGroup;
 import javax.swing.InputMap;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
@@ -73,7 +73,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 @Deprecated
-public class VisibilityAndGroupingDialog extends JDialog
+public class VisibilityAndGroupingDialog extends MemoryFixedDialog
 {
 	private static final long serialVersionUID = 1L;
 
@@ -117,7 +117,7 @@ public class VisibilityAndGroupingDialog extends JDialog
 		content.add( visibilityPanel );
 		content.add( groupingPanel );
 		content.add( modePanel );
-		getContentPane().add( content, BorderLayout.NORTH );
+		add( content, BorderLayout.NORTH );
 
 		final ActionMap am = getRootPane().getActionMap();
 		final InputMap im = getRootPane().getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
@@ -147,7 +147,6 @@ public class VisibilityAndGroupingDialog extends JDialog
 		} );
 
 		pack();
-		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 	}
 
 	public void update()

--- a/src/main/java/bdv/tools/VisibilityAndGroupingDialog.java
+++ b/src/main/java/bdv/tools/VisibilityAndGroupingDialog.java
@@ -28,7 +28,7 @@
  */
 package bdv.tools;
 
-import bdv.util.MemoryFixedDialog;
+import bdv.util.DelayedPackDialog;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerState;
 import bdv.viewer.VisibilityAndGrouping;
@@ -68,12 +68,11 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 @Deprecated
-public class VisibilityAndGroupingDialog extends MemoryFixedDialog
+public class VisibilityAndGroupingDialog extends DelayedPackDialog
 {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/bdv/tools/brightness/BrightnessDialog.java
+++ b/src/main/java/bdv/tools/brightness/BrightnessDialog.java
@@ -60,12 +60,11 @@ import javax.swing.JSpinner;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import bdv.util.InvokeOnEDT;
-import bdv.util.MemoryFixedDialog;
+import bdv.util.DelayedPackDialog;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
 import net.imglib2.type.numeric.ARGBType;
 
@@ -76,7 +75,7 @@ import net.imglib2.type.numeric.ARGBType;
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
 @Deprecated
-public class BrightnessDialog extends MemoryFixedDialog
+public class BrightnessDialog extends DelayedPackDialog
 {
 	public BrightnessDialog( final Frame owner, final SetupAssignments setupAssignments )
 	{

--- a/src/main/java/bdv/tools/brightness/BrightnessDialog.java
+++ b/src/main/java/bdv/tools/brightness/BrightnessDialog.java
@@ -65,6 +65,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import bdv.util.InvokeOnEDT;
+import bdv.util.MemoryFixedDialog;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
 import net.imglib2.type.numeric.ARGBType;
 
@@ -75,7 +76,7 @@ import net.imglib2.type.numeric.ARGBType;
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
 @Deprecated
-public class BrightnessDialog extends JDialog
+public class BrightnessDialog extends MemoryFixedDialog
 {
 	public BrightnessDialog( final Frame owner, final SetupAssignments setupAssignments )
 	{
@@ -148,7 +149,6 @@ public class BrightnessDialog extends JDialog
 		} );
 
 		pack();
-		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 	}
 
 	public static class ColorsPanel extends JPanel

--- a/src/main/java/bdv/ui/BdvDefaultCards.java
+++ b/src/main/java/bdv/ui/BdvDefaultCards.java
@@ -86,7 +86,7 @@ public class BdvDefaultCards
 		tablePanel.setPreferredSize( new Dimension( 300, 245 ) );
 
 		// -- Groups tree --
-		SourceGroupTree tree = new SourceGroupTree( state, viewer.getOptionValues().getInputTriggerConfig() );
+		final SourceGroupTree tree = new SourceGroupTree( state, viewer.getOptionValues().getInputTriggerConfig() );
 //		tree.setPreferredSize( new Dimension( 300, 200 ) );
 		tree.setVisibleRowCount( 10 );
 		tree.setEditable( true );
@@ -104,7 +104,6 @@ public class BdvDefaultCards
 		treePanel.add( editPanelTree, BorderLayout.SOUTH );
 		treePanel.setPreferredSize( new Dimension( 300, 225 ) );
 
-		// -- handle focus --
 		new FocusListener( tablePanel, table, treePanel, tree );
 
 		cards.addCard( DEFAULT_VIEWERMODES_CARD, "Display Modes", new DisplaySettingsPanel( viewer.state() ), true, new Insets( 0, 4, 4, 0 ) );
@@ -114,31 +113,26 @@ public class BdvDefaultCards
 
 	private static class FocusListener implements PropertyChangeListener
 	{
-
-		private final KeyboardFocusManager currentKeyboardFocusManager;
+		private final KeyboardFocusManager keyboardFocusManager;
 
 		private final WeakReference< JPanel > tablePanel;
-
 		private final WeakReference< SourceTable > table;
-
 		private final WeakReference< JPanel > treePanel;
-
 		private final WeakReference< SourceGroupTree > tree;
 
 		static final int MAX_DEPTH = 8;
-
 		boolean tableFocused;
-
 		boolean treeFocused;
 
-		FocusListener( JPanel tablePanel, SourceTable table, JPanel treePanel, SourceGroupTree tree )
+		FocusListener( final JPanel tablePanel, final SourceTable table, final JPanel treePanel, final SourceGroupTree tree )
 		{
 			this.tablePanel = new WeakReference<>( tablePanel );
 			this.table = new WeakReference<>( table );
 			this.treePanel = new WeakReference<>( treePanel );
 			this.tree = new WeakReference<>( tree );
-			currentKeyboardFocusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
-			currentKeyboardFocusManager.addPropertyChangeListener( "focusOwner", this );
+
+			keyboardFocusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
+			keyboardFocusManager.addPropertyChangeListener( "focusOwner", this );
 		}
 
 		void focusTable( final boolean focus )
@@ -146,7 +140,7 @@ public class BdvDefaultCards
 			if ( focus != tableFocused )
 			{
 				tableFocused = focus;
-				SourceTable table = this.table.get();
+				final SourceTable table = this.table.get();
 				if ( table != null )
 					table.setSelectionBackground( focus );
 			}
@@ -157,7 +151,7 @@ public class BdvDefaultCards
 			if ( focus != treeFocused )
 			{
 				treeFocused = focus;
-				SourceGroupTree tree = this.tree.get();
+				final SourceGroupTree tree = this.tree.get();
 				if ( tree != null )
 					tree.setSelectionBackground( focus );
 			}
@@ -166,28 +160,30 @@ public class BdvDefaultCards
 		@Override
 		public void propertyChange( final PropertyChangeEvent evt )
 		{
-			if ( tablePanel.get() == null && treePanel.get() == null )
+			final JPanel tablePanel = this.tablePanel.get();
+			final JPanel treePanel = this.treePanel.get();
+			if ( tablePanel == null && treePanel == null )
 			{
-				currentKeyboardFocusManager.removePropertyChangeListener( "focusOwner", this );
+				keyboardFocusManager.removePropertyChangeListener( "focusOwner", this );
 				return;
 			}
 
 			if ( evt.getNewValue() instanceof JComponent )
 			{
-				JComponent component = ( JComponent ) evt.getNewValue();
+				final JComponent component = ( JComponent ) evt.getNewValue();
 				for ( int i = 0; i < MAX_DEPTH; ++i )
 				{
-					Container parent = component.getParent();
+					final Container parent = component.getParent();
 					if ( !( parent instanceof JComponent ) )
 						break;
 
-					if ( component == treePanel.get() )
+					if ( component == treePanel )
 					{
 						focusTable( false );
 						focusTree( true );
 						return;
 					}
-					else if ( component == tablePanel.get() )
+					else if ( component == tablePanel )
 					{
 						focusTable( true );
 						focusTree( false );

--- a/src/main/java/bdv/util/DelayedPackDialog.java
+++ b/src/main/java/bdv/util/DelayedPackDialog.java
@@ -3,17 +3,14 @@ package bdv.util;
 import javax.swing.*;
 import java.awt.*;
 
-public class MemoryFixedDialog extends JDialog
+/**
+ * A {@code JDialog} that delays {@code pack()} calls until the dialog is made visible.
+ */
+public class DelayedPackDialog extends JDialog
 {
-	private boolean packIsPending = false;
+	private volatile boolean packIsPending = false;
 
-	public MemoryFixedDialog()
-	{
-		super();
-		super.setDefaultCloseOperation( WindowConstants.DISPOSE_ON_CLOSE );
-	}
-
-	public MemoryFixedDialog( Frame owner, String title, boolean modal )
+	public DelayedPackDialog( Frame owner, String title, boolean modal )
 	{
 		super( owner, title, modal );
 	}
@@ -39,11 +36,5 @@ public class MemoryFixedDialog extends JDialog
 			super.pack();
 		}
 		super.setVisible( visible );
-	}
-
-	@Override
-	public void setDefaultCloseOperation( int operation )
-	{
-		// do nothing
 	}
 }

--- a/src/main/java/bdv/util/MemoryFixedDialog.java
+++ b/src/main/java/bdv/util/MemoryFixedDialog.java
@@ -1,0 +1,49 @@
+package bdv.util;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class MemoryFixedDialog extends JDialog
+{
+	private boolean packIsPending = false;
+
+	public MemoryFixedDialog()
+	{
+		super();
+		super.setDefaultCloseOperation( WindowConstants.DISPOSE_ON_CLOSE );
+	}
+
+	public MemoryFixedDialog( Frame owner, String title, boolean modal )
+	{
+		super( owner, title, modal );
+	}
+
+	@Override
+	public void pack()
+	{
+		if ( isVisible() )
+		{
+			packIsPending = false;
+			super.pack();
+		}
+		else
+			packIsPending = true;
+	}
+
+	@Override
+	public void setVisible( boolean visible )
+	{
+		if ( visible && packIsPending )
+		{
+			packIsPending = false;
+			super.pack();
+		}
+		super.setVisible( visible );
+	}
+
+	@Override
+	public void setDefaultCloseOperation( int operation )
+	{
+		// do nothing
+	}
+}

--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -260,7 +260,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 
 		renderingExecutorService = Executors.newFixedThreadPool(
 				options.getNumRenderingThreads(),
-				new RenderThreadFactory(threadGroup) );
+				new RenderThreadFactory( threadGroup ) );
 		imageRenderer = new MultiResolutionRenderer(
 				renderTarget, painterThread,
 				options.getScreenScales(),
@@ -1155,7 +1155,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 
 	protected static class RenderThreadFactory implements ThreadFactory
 	{
-		private ThreadGroup threadGroup;
+		private final ThreadGroup threadGroup;
 
 		private final String threadNameFormat = String.format(
 				"bdv-panel-%d-thread-%%d",

--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -260,7 +260,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 
 		renderingExecutorService = Executors.newFixedThreadPool(
 				options.getNumRenderingThreads(),
-				new RenderThreadFactory() );
+				new RenderThreadFactory(threadGroup) );
 		imageRenderer = new MultiResolutionRenderer(
 				renderTarget, painterThread,
 				options.getScreenScales(),
@@ -1153,13 +1153,20 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 
 	protected static final AtomicInteger panelNumber = new AtomicInteger( 1 );
 
-	protected class RenderThreadFactory implements ThreadFactory
+	protected static class RenderThreadFactory implements ThreadFactory
 	{
+		private ThreadGroup threadGroup;
+
 		private final String threadNameFormat = String.format(
 				"bdv-panel-%d-thread-%%d",
 				panelNumber.getAndIncrement() );
 
 		private final AtomicInteger threadNumber = new AtomicInteger( 1 );
+
+		protected RenderThreadFactory( final ThreadGroup threadGroup )
+		{
+			this.threadGroup = threadGroup;
+		}
 
 		@Override
 		public Thread newThread( final Runnable r )


### PR DESCRIPTION
This PR fixes three reasons that prevented BDV to be properly garbage collected.

1. Using the method `pack()` of `JFrame` or `JDialog` will cause the window be refrenced (and prevent) garbage collection until `dispose()` is called. This is fixed by introducing `MemoryFixedDialog`. The dialog uses "DISPOSE_ON_CLOSE", and avoid's calling `pack()` as long as the dialog is invisible.
2. Remove unnecessary reference from `PainterThread` to `ViewerPanel`.
3. BdvDefaultCards, introduce weak reference when listening for keyboard focus.

Code that triggers the OutOfMemoryException (fixed by this PR):
```java
for ( int i = 0; i < 60; i++ )
{
	System.out.println( i );
	BdvFunctions.showOverlay( new BdvOverlay()
	{
		private final byte[] oneGigaByte = new byte[ 1 << 30 ];

		@Override
		protected void draw( Graphics2D g )
		{

		}
	}, "" ).close();
}
```