### PR TITLE
add flag to skip renderer's bounding box intersection

### DIFF
--- a/src/main/java/bdv/tools/transformation/TransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/TransformedSource.java
@@ -121,6 +121,12 @@ public class TransformedSource< T > implements Source< T >, MipmapOrdering
 		this.composed = new AffineTransform3D();
 	}
 
+	@Override
+	public boolean doBoundingBoxIntersectionCheck()
+	{
+		return source.doBoundingBoxIntersectionCheck();
+	}
+
 	/*
 	 * EXTRA TRANSFORMATION methods
 	 */

--- a/src/main/java/bdv/tools/transformation/TransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/TransformedSource.java
@@ -122,9 +122,9 @@ public class TransformedSource< T > implements Source< T >, MipmapOrdering
 	}
 
 	@Override
-	public boolean doBoundingBoxIntersectionCheck()
+	public boolean doBoundingBoxCulling()
 	{
-		return source.doBoundingBoxIntersectionCheck();
+		return source.doBoundingBoxCulling();
 	}
 
 	/*

--- a/src/main/java/bdv/util/RealRandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleSource.java
@@ -133,4 +133,10 @@ public abstract class RealRandomAccessibleSource< T extends Type< T > > implemen
 	{
 		return 1;
 	}
+
+	@Override
+	public boolean doBoundingBoxIntersectionCheck()
+	{
+		return doBoundingBoxIntersectionCheck;
+	}
 }

--- a/src/main/java/bdv/util/RealRandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleSource.java
@@ -57,17 +57,25 @@ public abstract class RealRandomAccessibleSource< T extends Type< T > > implemen
 
 	protected final VoxelDimensions voxelDimensions;
 
+	protected final boolean doBoundingBoxIntersectionCheck;
+
 	public RealRandomAccessibleSource( final RealRandomAccessible< T > accessible, final T type, final String name )
 	{
-		this( accessible, type, name, null );
+		this( accessible, type, name, null, false );
 	}
 
 	public RealRandomAccessibleSource( final RealRandomAccessible< T > accessible, final T type, final String name, final VoxelDimensions voxelDimensions )
+	{
+		this( accessible, type, name, voxelDimensions, false );
+	}
+
+	public RealRandomAccessibleSource( final RealRandomAccessible< T > accessible, final T type, final String name, final VoxelDimensions voxelDimensions, final boolean doBoundingBoxIntersectionCheck )
 	{
 		this.accessible = accessible;
 		this.type = type.createVariable();
 		this.name = name;
 		this.voxelDimensions = voxelDimensions;
+		this.doBoundingBoxIntersectionCheck = doBoundingBoxIntersectionCheck;
 	}
 
 	@Override

--- a/src/main/java/bdv/util/RealRandomAccessibleSource.java
+++ b/src/main/java/bdv/util/RealRandomAccessibleSource.java
@@ -135,7 +135,7 @@ public abstract class RealRandomAccessibleSource< T extends Type< T > > implemen
 	}
 
 	@Override
-	public boolean doBoundingBoxIntersectionCheck()
+	public boolean doBoundingBoxCulling()
 	{
 		return doBoundingBoxIntersectionCheck;
 	}

--- a/src/main/java/bdv/viewer/Source.java
+++ b/src/main/java/bdv/viewer/Source.java
@@ -68,6 +68,15 @@ public interface Source< T >
 	 */
 	public RandomAccessibleInterval< T > getSource( int t, int level );
 
+	/**
+	 * Should rendering skip the bounding
+	 * 
+	 * @return
+	 */
+	public default boolean doBoundingBoxIntersectionCheck()
+	{
+		return true;
+	}
 
 	/**
 	 * Get the 3D stack at timepoint index t, extended to infinity and interpolated.

--- a/src/main/java/bdv/viewer/Source.java
+++ b/src/main/java/bdv/viewer/Source.java
@@ -69,11 +69,18 @@ public interface Source< T >
 	public RandomAccessibleInterval< T > getSource( int t, int level );
 
 	/**
-	 * Should rendering skip the bounding
-	 * 
-	 * @return
+	 * Whether this source participates in bounding box culling.
+	 * <p>
+	 * If {@code true}, then this source will only be rendered if its bounding
+	 * box, i.e., the interval of {@link #getSource}, intersects the
+	 * current screen area (when transformed to viewer coordinates).
+	 * <p>
+	 * If {@code false}, then this source will be always rendered (if it is
+	 * set to be visible.)
+	 *
+	 * @return {@code true}, if this source participates in bounding box culling.
 	 */
-	public default boolean doBoundingBoxIntersectionCheck()
+	public default boolean doBoundingBoxCulling()
 	{
 		return true;
 	}

--- a/src/main/java/bdv/viewer/render/VisibilityUtils.java
+++ b/src/main/java/bdv/viewer/render/VisibilityUtils.java
@@ -83,7 +83,7 @@ class VisibilityUtils
 
 		for ( final SourceAndConverter< ? > source : sources )
 		{
-			if( !source.getSpimSource().doBoundingBoxIntersectionCheck() )
+			if( !source.getSpimSource().doBoundingBoxCulling() )
 			{
 				result.add( source );
 				continue;

--- a/src/main/java/bdv/viewer/render/VisibilityUtils.java
+++ b/src/main/java/bdv/viewer/render/VisibilityUtils.java
@@ -83,6 +83,12 @@ class VisibilityUtils
 
 		for ( final SourceAndConverter< ? > source : sources )
 		{
+			if( !source.getSpimSource().doBoundingBoxIntersectionCheck() )
+			{
+				result.add( source );
+				continue;
+			}
+
 			final Source< ? > spimSource = source.getSpimSource();
 			final int level = MipmapTransforms.getBestMipMapLevel( screenTransform, spimSource, t );
 			spimSource.getSourceTransform( t, level, sourceToScreen );


### PR DESCRIPTION
a default implementation preserves the current behavior 