### PR TITLE
Optionally position source name below coordinates

### DIFF
--- a/src/main/java/bdv/BigDataViewer.java
+++ b/src/main/java/bdv/BigDataViewer.java
@@ -28,7 +28,6 @@
  */
 package bdv;
 
-import bdv.util.Prefs;
 import bdv.viewer.ConverterSetups;
 import bdv.viewer.ViewerState;
 import java.io.File;
@@ -739,14 +738,12 @@ public class BigDataViewer
 //		final String fn = "/Users/pietzsch/Desktop/data/fibsem-remote.xml";
 //		final String fn = "/Users/pietzsch/Desktop/url-valia.xml";
 //		final String fn = "/Users/pietzsch/Desktop/data/clusterValia/140219-1/valia-140219-1.xml";
-//		final String fn = "/Users/pietzsch/workspace/data/111010_weber_full.xml";
+		final String fn = "/Users/pietzsch/workspace/data/111010_weber_full.xml";
 //		final String fn = "/Volumes/projects/tomancak_lightsheet/Mette/ZeissZ1SPIM/Maritigrella/021013_McH2BsGFP_CAAX-mCherry/11-use/hdf5/021013_McH2BsGFP_CAAX-mCherry-11-use.xml";
-		final String fn = "/Users/tischer/Documents/bigdataviewer-playground/src/test/resources/mri-stack.xml";
 		try
 		{
 			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
 
-			Prefs.positionTextOverlayBelowCoordinates( true );
 			final BigDataViewer bdv = open( fn, new File( fn ).getName(), new ProgressWriterConsole(), ViewerOptions.options() );
 
 //			DumpInputConfig.writeToYaml( System.getProperty( "user.home" ) + "/.bdv/bdvkeyconfig.yaml", bdv.getViewerFrame() );

--- a/src/main/java/bdv/BigDataViewer.java
+++ b/src/main/java/bdv/BigDataViewer.java
@@ -28,6 +28,7 @@
  */
 package bdv;
 
+import bdv.util.Prefs;
 import bdv.viewer.ConverterSetups;
 import bdv.viewer.ViewerState;
 import java.io.File;
@@ -738,12 +739,14 @@ public class BigDataViewer
 //		final String fn = "/Users/pietzsch/Desktop/data/fibsem-remote.xml";
 //		final String fn = "/Users/pietzsch/Desktop/url-valia.xml";
 //		final String fn = "/Users/pietzsch/Desktop/data/clusterValia/140219-1/valia-140219-1.xml";
-		final String fn = "/Users/pietzsch/workspace/data/111010_weber_full.xml";
+//		final String fn = "/Users/pietzsch/workspace/data/111010_weber_full.xml";
 //		final String fn = "/Volumes/projects/tomancak_lightsheet/Mette/ZeissZ1SPIM/Maritigrella/021013_McH2BsGFP_CAAX-mCherry/11-use/hdf5/021013_McH2BsGFP_CAAX-mCherry-11-use.xml";
+		final String fn = "/Users/tischer/Documents/bigdataviewer-playground/src/test/resources/mri-stack.xml";
 		try
 		{
 			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
 
+			Prefs.leftAlignedTextOverlay( false );
 			final BigDataViewer bdv = open( fn, new File( fn ).getName(), new ProgressWriterConsole(), ViewerOptions.options() );
 
 //			DumpInputConfig.writeToYaml( System.getProperty( "user.home" ) + "/.bdv/bdvkeyconfig.yaml", bdv.getViewerFrame() );

--- a/src/main/java/bdv/BigDataViewer.java
+++ b/src/main/java/bdv/BigDataViewer.java
@@ -746,7 +746,7 @@ public class BigDataViewer
 		{
 			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
 
-			Prefs.leftAlignedTextOverlay( false );
+			Prefs.positionTextOverlayBelowCoordinates( true );
 			final BigDataViewer bdv = open( fn, new File( fn ).getName(), new ProgressWriterConsole(), ViewerOptions.options() );
 
 //			DumpInputConfig.writeToYaml( System.getProperty( "user.home" ) + "/.bdv/bdvkeyconfig.yaml", bdv.getViewerFrame() );

--- a/src/main/java/bdv/util/Prefs.java
+++ b/src/main/java/bdv/util/Prefs.java
@@ -51,6 +51,8 @@ public class Prefs
 		return getInstance().showTextOverlay;
 	}
 
+	public static boolean leftAlignedTextOverlay() { return getInstance().leftAlignedTextOverlay; }
+
 	public static boolean showScaleBarInMovie()
 	{
 		return getInstance().showScaleBarInMovie;
@@ -81,6 +83,8 @@ public class Prefs
 		getInstance().showTextOverlay = show;
 	}
 
+	public static void leftAlignedTextOverlay( final boolean leftAligned ) { getInstance().leftAlignedTextOverlay = leftAligned; }
+
 	public static void showScaleBarInMovie( final boolean show )
 	{
 		getInstance().showScaleBarInMovie = show;
@@ -110,6 +114,7 @@ public class Prefs
 	private static final String SHOW_SCALE_BAR = "show-scale-bar";
 	private static final String SHOW_MULTIBOX_OVERLAY = "show-multibox-overlay";
 	private static final String SHOW_TEXT_OVERLAY = "show-text-overlay";
+	private static final String LEFT_ALIGNED_TEXT_OVERLAY = "left-aligned-text-overlay";
 	private static final String SHOW_SCALE_BAR_IN_MOVIE = "show-scale-bar-in-movie";
 	private static final String SCALE_BAR_COLOR = "scale-bar-color";
 	private static final String SCALE_BAR_BG_COLOR = "scale-bar-bg-color";
@@ -117,6 +122,7 @@ public class Prefs
 	private boolean showScaleBar;
 	private boolean showMultibox;
 	private boolean showTextOverlay;
+	private boolean leftAlignedTextOverlay;
 	private boolean showScaleBarInMovie;
 	private int scaleBarColor;
 	private int scaleBarBgColor;
@@ -126,6 +132,7 @@ public class Prefs
 		showScaleBar = getBoolean( p, SHOW_SCALE_BAR, false );
 		showMultibox = getBoolean( p, SHOW_MULTIBOX_OVERLAY, true );
 		showTextOverlay = getBoolean( p, SHOW_TEXT_OVERLAY, true );
+		leftAlignedTextOverlay = getBoolean( p, LEFT_ALIGNED_TEXT_OVERLAY, false );
 		showScaleBarInMovie = getBoolean( p, SHOW_SCALE_BAR_IN_MOVIE, false );
 		scaleBarColor = getInt( p, SCALE_BAR_COLOR, 0xffffffff );
 		scaleBarBgColor = getInt( p, SCALE_BAR_BG_COLOR, 0x88000000 );
@@ -205,6 +212,7 @@ public class Prefs
 		properties.put( SHOW_SCALE_BAR, "" + prefs.showScaleBar );
 		properties.put( SHOW_MULTIBOX_OVERLAY, "" + prefs.showMultibox );
 		properties.put( SHOW_TEXT_OVERLAY, "" + prefs.showTextOverlay );
+		properties.put( LEFT_ALIGNED_TEXT_OVERLAY, "" + prefs.leftAlignedTextOverlay );
 		properties.put( SHOW_SCALE_BAR_IN_MOVIE, "" + prefs.showScaleBarInMovie );
 		properties.put( SCALE_BAR_COLOR, "" + prefs.scaleBarColor );
 		properties.put( SCALE_BAR_BG_COLOR, "" + prefs.scaleBarBgColor );

--- a/src/main/java/bdv/util/Prefs.java
+++ b/src/main/java/bdv/util/Prefs.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import static bdv.util.Prefs.OverlayPosition.TOP_CENTER;
+
 public class Prefs
 {
 	public static boolean showScaleBar()
@@ -51,7 +53,10 @@ public class Prefs
 		return getInstance().showTextOverlay;
 	}
 
-	public static boolean positionTextOverlayBelowCoordinates() { return getInstance().positionTextOverlayBelowCoordinates; }
+	public static OverlayPosition sourceNameOverlayPosition()
+	{
+		return getInstance().sourceNameOverlayPosition;
+	}
 
 	public static boolean showScaleBarInMovie()
 	{
@@ -83,7 +88,10 @@ public class Prefs
 		getInstance().showTextOverlay = show;
 	}
 
-	public static void positionTextOverlayBelowCoordinates( final boolean positionBelowCoordinates ) { getInstance().positionTextOverlayBelowCoordinates = positionBelowCoordinates; }
+	public static void sourceNameOverlayPosition( final OverlayPosition position )
+	{
+		getInstance().sourceNameOverlayPosition = position;
+	}
 
 	public static void showScaleBarInMovie( final boolean show )
 	{
@@ -111,10 +119,16 @@ public class Prefs
 		return instance;
 	}
 
+	public enum OverlayPosition
+	{
+		TOP_CENTER, // centered at the top. default
+		TOP_RIGHT   // aligned with the position and time point overlays
+	}
+
 	private static final String SHOW_SCALE_BAR = "show-scale-bar";
 	private static final String SHOW_MULTIBOX_OVERLAY = "show-multibox-overlay";
 	private static final String SHOW_TEXT_OVERLAY = "show-text-overlay";
-	private static final String LEFT_ALIGNED_TEXT_OVERLAY = "left-aligned-text-overlay";
+	private static final String SOURCE_NAME_OVERLAY_POSITION = "source-name-overlay-position";
 	private static final String SHOW_SCALE_BAR_IN_MOVIE = "show-scale-bar-in-movie";
 	private static final String SCALE_BAR_COLOR = "scale-bar-color";
 	private static final String SCALE_BAR_BG_COLOR = "scale-bar-bg-color";
@@ -122,7 +136,7 @@ public class Prefs
 	private boolean showScaleBar;
 	private boolean showMultibox;
 	private boolean showTextOverlay;
-	private boolean positionTextOverlayBelowCoordinates;
+	private OverlayPosition sourceNameOverlayPosition;
 	private boolean showScaleBarInMovie;
 	private int scaleBarColor;
 	private int scaleBarBgColor;
@@ -132,7 +146,7 @@ public class Prefs
 		showScaleBar = getBoolean( p, SHOW_SCALE_BAR, false );
 		showMultibox = getBoolean( p, SHOW_MULTIBOX_OVERLAY, true );
 		showTextOverlay = getBoolean( p, SHOW_TEXT_OVERLAY, true );
-		positionTextOverlayBelowCoordinates = getBoolean( p, LEFT_ALIGNED_TEXT_OVERLAY, false );
+		sourceNameOverlayPosition = getOverlayPosition( p, SOURCE_NAME_OVERLAY_POSITION, TOP_CENTER );
 		showScaleBarInMovie = getBoolean( p, SHOW_SCALE_BAR_IN_MOVIE, false );
 		scaleBarColor = getInt( p, SCALE_BAR_COLOR, 0xffffffff );
 		scaleBarBgColor = getInt( p, SCALE_BAR_BG_COLOR, 0x88000000 );
@@ -166,6 +180,20 @@ public class Prefs
 			return ( property != null ) ? Double.parseDouble( property ) : defaultValue;
 		}
 		catch ( final NumberFormatException e )
+		{
+			e.printStackTrace();
+			return defaultValue;
+		}
+	}
+
+	private OverlayPosition getOverlayPosition( final Properties p, final String key, final OverlayPosition defaultValue )
+	{
+		try
+		{
+			final String property = ( p != null ) ? p.getProperty( key ) : null;
+			return ( property != null ) ? OverlayPosition.valueOf( property ) : defaultValue;
+		}
+		catch ( final IllegalArgumentException e )
 		{
 			e.printStackTrace();
 			return defaultValue;
@@ -212,7 +240,7 @@ public class Prefs
 		properties.put( SHOW_SCALE_BAR, "" + prefs.showScaleBar );
 		properties.put( SHOW_MULTIBOX_OVERLAY, "" + prefs.showMultibox );
 		properties.put( SHOW_TEXT_OVERLAY, "" + prefs.showTextOverlay );
-		properties.put( LEFT_ALIGNED_TEXT_OVERLAY, "" + prefs.positionTextOverlayBelowCoordinates );
+		properties.put( SOURCE_NAME_OVERLAY_POSITION, "" + prefs.sourceNameOverlayPosition );
 		properties.put( SHOW_SCALE_BAR_IN_MOVIE, "" + prefs.showScaleBarInMovie );
 		properties.put( SCALE_BAR_COLOR, "" + prefs.scaleBarColor );
 		properties.put( SCALE_BAR_BG_COLOR, "" + prefs.scaleBarBgColor );

--- a/src/main/java/bdv/util/Prefs.java
+++ b/src/main/java/bdv/util/Prefs.java
@@ -51,7 +51,7 @@ public class Prefs
 		return getInstance().showTextOverlay;
 	}
 
-	public static boolean leftAlignedTextOverlay() { return getInstance().leftAlignedTextOverlay; }
+	public static boolean positionTextOverlayBelowCoordinates() { return getInstance().positionTextOverlayBelowCoordinates; }
 
 	public static boolean showScaleBarInMovie()
 	{
@@ -83,7 +83,7 @@ public class Prefs
 		getInstance().showTextOverlay = show;
 	}
 
-	public static void leftAlignedTextOverlay( final boolean leftAligned ) { getInstance().leftAlignedTextOverlay = leftAligned; }
+	public static void positionTextOverlayBelowCoordinates( final boolean positionBelowCoordinates ) { getInstance().positionTextOverlayBelowCoordinates = positionBelowCoordinates; }
 
 	public static void showScaleBarInMovie( final boolean show )
 	{
@@ -122,7 +122,7 @@ public class Prefs
 	private boolean showScaleBar;
 	private boolean showMultibox;
 	private boolean showTextOverlay;
-	private boolean leftAlignedTextOverlay;
+	private boolean positionTextOverlayBelowCoordinates;
 	private boolean showScaleBarInMovie;
 	private int scaleBarColor;
 	private int scaleBarBgColor;
@@ -132,7 +132,7 @@ public class Prefs
 		showScaleBar = getBoolean( p, SHOW_SCALE_BAR, false );
 		showMultibox = getBoolean( p, SHOW_MULTIBOX_OVERLAY, true );
 		showTextOverlay = getBoolean( p, SHOW_TEXT_OVERLAY, true );
-		leftAlignedTextOverlay = getBoolean( p, LEFT_ALIGNED_TEXT_OVERLAY, false );
+		positionTextOverlayBelowCoordinates = getBoolean( p, LEFT_ALIGNED_TEXT_OVERLAY, false );
 		showScaleBarInMovie = getBoolean( p, SHOW_SCALE_BAR_IN_MOVIE, false );
 		scaleBarColor = getInt( p, SCALE_BAR_COLOR, 0xffffffff );
 		scaleBarBgColor = getInt( p, SCALE_BAR_BG_COLOR, 0x88000000 );
@@ -212,7 +212,7 @@ public class Prefs
 		properties.put( SHOW_SCALE_BAR, "" + prefs.showScaleBar );
 		properties.put( SHOW_MULTIBOX_OVERLAY, "" + prefs.showMultibox );
 		properties.put( SHOW_TEXT_OVERLAY, "" + prefs.showTextOverlay );
-		properties.put( LEFT_ALIGNED_TEXT_OVERLAY, "" + prefs.leftAlignedTextOverlay );
+		properties.put( LEFT_ALIGNED_TEXT_OVERLAY, "" + prefs.positionTextOverlayBelowCoordinates );
 		properties.put( SHOW_SCALE_BAR_IN_MOVIE, "" + prefs.showScaleBarInMovie );
 		properties.put( SCALE_BAR_COLOR, "" + prefs.scaleBarColor );
 		properties.put( SCALE_BAR_BG_COLOR, "" + prefs.scaleBarBgColor );

--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -517,6 +517,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 		if ( Prefs.showTextOverlay() )
 		{
 			sourceInfoOverlayRenderer.setViewerState( state() );
+			sourceInfoOverlayRenderer.paintSourceAndGroupNamesLeftAligned( Prefs.leftAlignedTextOverlay() );
 			sourceInfoOverlayRenderer.paint( ( Graphics2D ) g );
 
 			final RealPoint gPos = new RealPoint( 3 );

--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -517,7 +517,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 		if ( Prefs.showTextOverlay() )
 		{
 			sourceInfoOverlayRenderer.setViewerState( state() );
-			sourceInfoOverlayRenderer.drawSourceAndGroupNameBelowCoordinates( Prefs.positionTextOverlayBelowCoordinates() );
+			sourceInfoOverlayRenderer.setSourceNameOverlayPosition( Prefs.sourceNameOverlayPosition() );
 			sourceInfoOverlayRenderer.paint( ( Graphics2D ) g );
 
 			final RealPoint gPos = new RealPoint( 3 );

--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -517,7 +517,7 @@ public class ViewerPanel extends JPanel implements OverlayRenderer, PainterThrea
 		if ( Prefs.showTextOverlay() )
 		{
 			sourceInfoOverlayRenderer.setViewerState( state() );
-			sourceInfoOverlayRenderer.paintSourceAndGroupNamesLeftAligned( Prefs.leftAlignedTextOverlay() );
+			sourceInfoOverlayRenderer.drawSourceAndGroupNameBelowCoordinates( Prefs.positionTextOverlayBelowCoordinates() );
 			sourceInfoOverlayRenderer.paint( ( Graphics2D ) g );
 
 			final RealPoint gPos = new RealPoint( 3 );

--- a/src/main/java/bdv/viewer/overlay/SourceInfoOverlayRenderer.java
+++ b/src/main/java/bdv/viewer/overlay/SourceInfoOverlayRenderer.java
@@ -52,11 +52,23 @@ public class SourceInfoOverlayRenderer
 
 	protected String timepointString;
 
+	protected boolean paintSourceAndGroupNamesLeftAligned;
+
 	public synchronized void paint( final Graphics2D g )
 	{
 		g.setFont( new Font( "Monospaced", Font.PLAIN, 12 ) );
-		g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() / 2, 12 );
-		g.drawString( groupName, ( int ) g.getClipBounds().getWidth() / 2, 25 );
+
+		if ( paintSourceAndGroupNamesLeftAligned )
+		{
+			g.drawString( sourceName, 12, 12 );
+			g.drawString( groupName, 12, 25 );
+		}
+		else
+		{
+			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() / 2, 12 );
+			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() / 2, 25 );
+		}
+
 		g.drawString( timepointString, ( int ) g.getClipBounds().getWidth() - 170, 12 );
 	}
 
@@ -98,5 +110,10 @@ public class SourceInfoOverlayRenderer
 			else
 				timepointString = String.format( "t = %d", t );
 		}
+	}
+
+	public void paintSourceAndGroupNamesLeftAligned( boolean leftAligned )
+	{
+		this.paintSourceAndGroupNamesLeftAligned = leftAligned;
 	}
 }

--- a/src/main/java/bdv/viewer/overlay/SourceInfoOverlayRenderer.java
+++ b/src/main/java/bdv/viewer/overlay/SourceInfoOverlayRenderer.java
@@ -28,6 +28,7 @@
  */
 package bdv.viewer.overlay;
 
+import bdv.util.Prefs.OverlayPosition;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.util.List;
@@ -35,6 +36,8 @@ import java.util.List;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerState;
 import mpicbg.spim.data.sequence.TimePoint;
+
+import static bdv.util.Prefs.OverlayPosition.TOP_CENTER;
 
 /**
  * Render current source name and current timepoint of a {@link ViewerState}
@@ -52,7 +55,7 @@ public class SourceInfoOverlayRenderer
 
 	protected String timepointString;
 
-	protected boolean drawSourceAndGroupNameBelowCoordinates;
+	protected OverlayPosition sourceNameOverlayPosition = TOP_CENTER;
 
 	public synchronized void paint( final Graphics2D g )
 	{
@@ -61,17 +64,19 @@ public class SourceInfoOverlayRenderer
 
 		g.setFont( new Font( "Monospaced", Font.PLAIN, fontSize ) );
 
-		g.drawString( timepointString, ( int ) g.getClipBounds().getWidth() - 170, spacing );
+		g.drawString( timepointString, ( int ) g.getClipBounds().getWidth() - 170, spacing - 1 );
 
-		if ( drawSourceAndGroupNameBelowCoordinates )
+		switch ( sourceNameOverlayPosition )
 		{
-			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() - Math.max( g.getFontMetrics().stringWidth( sourceName ) + 17, 170 ) , 3 * spacing );
-			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() - Math.max( g.getFontMetrics().stringWidth( groupName ) + 17, 170 ) , 4 * spacing );
-		}
-		else
-		{
-			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() / 2, spacing );
-			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() / 2, 2 * spacing );
+		default:
+		case TOP_CENTER:
+			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() / 2, spacing - 1 );
+			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() / 2, 2 * spacing - 1 );
+			break;
+		case TOP_RIGHT:
+			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() - Math.max( g.getFontMetrics().stringWidth( sourceName ) + 17, 170 ) , 3 * spacing - 1 );
+			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() - Math.max( g.getFontMetrics().stringWidth( groupName ) + 17, 170 ) , 4 * spacing - 1 );
+			break;
 		}
 	}
 
@@ -115,8 +120,8 @@ public class SourceInfoOverlayRenderer
 		}
 	}
 
-	public void drawSourceAndGroupNameBelowCoordinates( boolean drawBelowCoordinates )
+	public void setSourceNameOverlayPosition( final OverlayPosition position )
 	{
-		this.drawSourceAndGroupNameBelowCoordinates = drawBelowCoordinates;
+		this.sourceNameOverlayPosition = position;
 	}
 }

--- a/src/main/java/bdv/viewer/overlay/SourceInfoOverlayRenderer.java
+++ b/src/main/java/bdv/viewer/overlay/SourceInfoOverlayRenderer.java
@@ -52,24 +52,27 @@ public class SourceInfoOverlayRenderer
 
 	protected String timepointString;
 
-	protected boolean paintSourceAndGroupNamesLeftAligned;
+	protected boolean drawSourceAndGroupNameBelowCoordinates;
 
 	public synchronized void paint( final Graphics2D g )
 	{
-		g.setFont( new Font( "Monospaced", Font.PLAIN, 12 ) );
+		final int fontSize = 12;
+		final int spacing = fontSize + 1;
 
-		if ( paintSourceAndGroupNamesLeftAligned )
+		g.setFont( new Font( "Monospaced", Font.PLAIN, fontSize ) );
+
+		g.drawString( timepointString, ( int ) g.getClipBounds().getWidth() - 170, spacing );
+
+		if ( drawSourceAndGroupNameBelowCoordinates )
 		{
-			g.drawString( sourceName, 12, 12 );
-			g.drawString( groupName, 12, 25 );
+			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() - Math.max( g.getFontMetrics().stringWidth( sourceName ) + 17, 170 ) , 3 * spacing );
+			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() - Math.max( g.getFontMetrics().stringWidth( groupName ) + 17, 170 ) , 4 * spacing );
 		}
 		else
 		{
-			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() / 2, 12 );
-			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() / 2, 25 );
+			g.drawString( sourceName, ( int ) g.getClipBounds().getWidth() / 2, spacing );
+			g.drawString( groupName, ( int ) g.getClipBounds().getWidth() / 2, 2 * spacing );
 		}
-
-		g.drawString( timepointString, ( int ) g.getClipBounds().getWidth() - 170, 12 );
 	}
 
 	public synchronized void setTimePointsOrdered( final List< TimePoint > timePointsOrdered )
@@ -112,8 +115,8 @@ public class SourceInfoOverlayRenderer
 		}
 	}
 
-	public void paintSourceAndGroupNamesLeftAligned( boolean leftAligned )
+	public void drawSourceAndGroupNameBelowCoordinates( boolean drawBelowCoordinates )
 	{
-		this.paintSourceAndGroupNamesLeftAligned = leftAligned;
+		this.drawSourceAndGroupNameBelowCoordinates = drawBelowCoordinates;
 	}
 }


### PR DESCRIPTION
Addresses #109

I realised that positioning the source and group names below the coordinates does an even better job in terms of not clashing with them than left alignment. 

It has the additional benefit of keeping out of the way of the multi-box overlay. 

I also like visually that all the text information is shown as one block.

`Prefs.positionTextOverlayBelowCoordinates( true );`

![image](https://user-images.githubusercontent.com/2157566/98446791-6c9f9580-2120-11eb-8376-5dc616e3788e.png)

I don't really like the name `positionTextOverlayBelowCoordinates` as it is very verbose, but I did not have a shorter idea right now.

What do you think?
