### PR TITLE
Add central pixel downsampling method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,8 @@
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>bigdataviewer-core</artifactId>
-	<version>10.2.1-SNAPSHOT</version>
+<!--	<version>10.2.1-SNAPSHOT</version> -->
+	<version>10.2.1-TISCHI</version>
 
 	<name>BigDataViewer Core</name>
 	<description>BigDataViewer core classes with minimal dependencies.</description>

--- a/src/main/java/bdv/export/DownsampleBlock.java
+++ b/src/main/java/bdv/export/DownsampleBlock.java
@@ -29,6 +29,8 @@
 package bdv.export;
 
 import java.util.Arrays;
+import java.util.HashSet;
+
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.array.ArrayImgs;
@@ -382,6 +384,7 @@ class DownsampleLabelBlockInstances
 				final int asx, // size of output (resp accumulator) image
 				final RandomAccess< T > in )
 		{
+
 			final int bsx = downsamplingFactors[ 0 ];
 			final int sx = asx * bsx;
 			for ( int x = 0, bx = 0; x < sx; ++x )

--- a/src/main/java/bdv/export/DownsampleBlock.java
+++ b/src/main/java/bdv/export/DownsampleBlock.java
@@ -60,7 +60,7 @@ class DownsampleBlockInstances
 	public static < T extends RealType< T > > DownsampleBlock< T > create(
 			final int[] blockDimensions,
 			final int[] downsamplingFactors,
-			final Class< ?  > pixelTypeClass,
+			final Class< ? > pixelTypeClass,
 			final Class< ? > inAccessClass )
 	{
 		if ( provider == null )
@@ -120,13 +120,11 @@ class DownsampleBlockInstances
 			{
 				downsampleBlock3D( acc, dimensions[ 0 ], dimensions[ 1 ], dimensions[ 2 ], in );
 				writeOutput3D( out, dimensions[ 0 ], dimensions[ 1 ], dimensions[ 2 ], acc );
-			}
-			else if ( n == 2 )
+			} else if ( n == 2 )
 			{
 				downsampleBlock2D( acc, dimensions[ 0 ], dimensions[ 1 ], in );
 				writeOutput2D( out, dimensions[ 0 ], dimensions[ 1 ], acc );
-			}
-			else
+			} else
 			{
 				downsampleBlock1D( acc, dimensions[ 0 ], in );
 				writeOutput1D( out, dimensions[ 0 ], acc );
@@ -248,3 +246,200 @@ class DownsampleBlockInstances
 		}
 	}
 }
+
+class DownsampleLabelBlockInstances
+{
+	@SuppressWarnings( "rawtypes" )
+	private static ClassCopyProvider< DownsampleBlock > provider;
+
+	@SuppressWarnings( "unchecked" )
+	public static < T extends RealType< T > > DownsampleBlock< T > create(
+			final int[] blockDimensions,
+			final int[] downsamplingFactors,
+			final Class< ? > pixelTypeClass,
+			final Class< ? > inAccessClass )
+	{
+		if ( provider == null )
+		{
+			synchronized ( bdv.export.DownsampleBlockInstances.class )
+			{
+				if ( provider == null )
+					provider = new ClassCopyProvider<>( bdv.export.DownsampleBlockInstances.Imp.class, DownsampleBlock.class, int[].class, int[].class );
+			}
+		}
+
+		final int numDimensions = blockDimensions.length;
+
+		Object key = Arrays.asList( numDimensions, pixelTypeClass, inAccessClass );
+		return provider.newInstanceForKey( key, blockDimensions, downsamplingFactors );
+	}
+
+	public static class LabelImp< T extends RealType< T > > implements DownsampleBlock< T >
+	{
+		private final int n;
+
+		private final int[] downsamplingFactors;
+
+		private final double scale;
+
+		private final double[] accumulator;
+
+		private final RandomAccess< DoubleType > acc;
+
+		public LabelImp(
+				final int[] blockDimensions,
+				final int[] downsamplingFactors )
+		{
+			n = blockDimensions.length;
+			if ( n < 1 || n > 3 )
+				throw new IllegalArgumentException();
+
+			this.downsamplingFactors = downsamplingFactors;
+			scale = 1.0 / Intervals.numElements( downsamplingFactors );
+
+			accumulator = new double[ ( int ) Intervals.numElements( blockDimensions ) ];
+
+			final long[] dims = new long[ n ];
+			Arrays.setAll( dims, d -> blockDimensions[ d ] );
+			acc = ArrayImgs.doubles( accumulator, dims ).randomAccess();
+		}
+
+		@Override
+		public void downsampleBlock(
+				final RandomAccess< T > in,
+				final Cursor< T > out, // must be flat iteration order
+				final int[] dimensions )
+		{
+			clearAccumulator();
+
+			if ( n == 3 )
+			{
+				downsampleBlock3D( acc, dimensions[ 0 ], dimensions[ 1 ], dimensions[ 2 ], in );
+				writeOutput3D( out, dimensions[ 0 ], dimensions[ 1 ], dimensions[ 2 ], acc );
+			} else if ( n == 2 )
+			{
+				downsampleBlock2D( acc, dimensions[ 0 ], dimensions[ 1 ], in );
+				writeOutput2D( out, dimensions[ 0 ], dimensions[ 1 ], acc );
+			} else
+			{
+				downsampleBlock1D( acc, dimensions[ 0 ], in );
+				writeOutput1D( out, dimensions[ 0 ], acc );
+			}
+		}
+
+		private void clearAccumulator()
+		{
+			Arrays.fill( accumulator, 0, accumulator.length, 0 );
+		}
+
+		private void downsampleBlock3D(
+				final RandomAccess< DoubleType > acc,
+				final int asx, // size of output (resp accumulator) image
+				final int asy,
+				final int asz,
+				final RandomAccess< T > in )
+		{
+			final int bsz = downsamplingFactors[ 2 ];
+			final int sz = asz * bsz;
+			for ( int z = 0, bz = 0; z < sz; ++z )
+			{
+				downsampleBlock2D( acc, asx, asy, in );
+				in.fwd( 2 );
+				if ( ++bz == bsz )
+				{
+					bz = 0;
+					acc.fwd( 2 );
+				}
+			}
+			in.move( -sz, 2 );
+			acc.move( -asz, 2 );
+		}
+
+		private void downsampleBlock2D(
+				final RandomAccess< DoubleType > acc,
+				final int asx, // size of output (resp accumulator) image
+				final int asy,
+				final RandomAccess< T > in )
+		{
+			final int bsy = downsamplingFactors[ 1 ];
+			final int sy = asy * bsy;
+			for ( int y = 0, by = 0; y < sy; ++y )
+			{
+				downsampleBlock1D( acc, asx, in );
+				in.fwd( 1 );
+				if ( ++by == bsy )
+				{
+					by = 0;
+					acc.fwd( 1 );
+				}
+			}
+			in.move( -sy, 1 );
+			acc.move( -asy, 1 );
+		}
+
+		private void downsampleBlock1D(
+				final RandomAccess< DoubleType > acc,
+				final int asx, // size of output (resp accumulator) image
+				final RandomAccess< T > in )
+		{
+			final int bsx = downsamplingFactors[ 0 ];
+			final int sx = asx * bsx;
+			for ( int x = 0, bx = 0; x < sx; ++x )
+			{
+				acc.get().set( acc.get().get() + in.get().getRealDouble() );
+				in.fwd( 0 );
+				if ( ++bx == bsx )
+				{
+					bx = 0;
+					acc.fwd( 0 );
+				}
+			}
+			in.move( -sx, 0 );
+			acc.move( -asx, 0 );
+		}
+
+		private void writeOutput3D(
+				final Cursor< T > out, // must be flat iteration order
+				final int asx, // size of output (resp accumulator) image
+				final int asy,
+				final int asz,
+				final RandomAccess< DoubleType > acc )
+		{
+			for ( int z = 0; z < asz; ++z )
+			{
+				writeOutput2D( out, asx, asy, acc );
+				acc.fwd( 2 );
+			}
+			acc.move( -asz, 2 );
+		}
+
+		private void writeOutput2D(
+				final Cursor< T > out, // must be flat iteration order
+				final int asx, // size of output (resp accumulator) image
+				final int asy,
+				final RandomAccess< DoubleType > acc )
+		{
+			for ( int y = 0; y < asy; ++y )
+			{
+				writeOutput1D( out, asx, acc );
+				acc.fwd( 1 );
+			}
+			acc.move( -asy, 1 );
+		}
+
+		private void writeOutput1D(
+				final Cursor< T > out, // must be flat iteration order
+				final int asx, // size of output (resp accumulator) image
+				final RandomAccess< DoubleType > acc )
+		{
+			final double scale = this.scale;
+			for ( int x = 0; x < asx; ++x )
+			{
+				out.next().setReal( acc.get().get() * scale );
+				acc.fwd( 0 );
+			}
+			acc.move( -asx, 0 );
+		}
+	}
+}
+

--- a/src/main/java/bdv/export/ExportScalePyramid.java
+++ b/src/main/java/bdv/export/ExportScalePyramid.java
@@ -227,6 +227,7 @@ public class ExportScalePyramid
 			final RandomAccessibleInterval< T > img,
 			final T type,
 			final ExportMipmapInfo mipmapInfo,
+			final DownsampleBlock.DownsamplingMethod downsamplingMethod,
 			final DatasetIO< D, T > io,
 			final ExecutorService executorService,
 			final int numThreads,
@@ -362,7 +363,7 @@ public class ExportScalePyramid
 						final Class< ? extends RealType > kl1 = type.getClass();
 						final Class< ? extends RandomAccess > kl2 = in.getClass();
 						final CopyBlock< T > copyBlock = fullResolution ? CopyBlock.create( n, kl1, kl2 ) : null;
-						final DownsampleBlock< T > downsampleBlock = fullResolution ? null : DownsampleBlock.create( cellDimensions, factor, kl1, kl2 );
+						final DownsampleBlock< T > downsampleBlock = fullResolution ? null : DownsampleBlock.create( cellDimensions, factor, downsamplingMethod, kl1, kl2 );
 
 						for ( int i = nextCellInPlane.getAndIncrement(); i < numBlocksPerPlane; i = nextCellInPlane.getAndIncrement() )
 						{

--- a/src/main/java/bdv/export/n5/WriteSequenceToN5.java
+++ b/src/main/java/bdv/export/n5/WriteSequenceToN5.java
@@ -28,11 +28,7 @@
  */
 package bdv.export.n5;
 
-import bdv.export.ExportMipmapInfo;
-import bdv.export.ExportScalePyramid;
-import bdv.export.ProgressWriter;
-import bdv.export.ProgressWriterNull;
-import bdv.export.SubTaskProgressWriter;
+import bdv.export.*;
 import bdv.export.ExportScalePyramid.AfterEachPlane;
 import bdv.export.ExportScalePyramid.LoopbackHeuristic;
 import bdv.img.cache.SimpleCacheArrayLoader;
@@ -253,7 +249,7 @@ public class WriteSequenceToN5
 		final T type = setupImgLoader.getImageType();
 		final N5DatasetIO< T > io = new N5DatasetIO<>( n5, compression, setupId, timepointId, type );
 		ExportScalePyramid.writeScalePyramid(
-				img, type, mipmapInfo, io,
+				img, type, mipmapInfo, DownsampleBlock.DownsamplingMethod.Average, io,
 				executorService, numThreads,
 				loopbackHeuristic, afterEachPlane, progressWriter );
 	}

--- a/src/main/java/bdv/tools/crop/CropDialog.java
+++ b/src/main/java/bdv/tools/crop/CropDialog.java
@@ -28,6 +28,7 @@
  */
 package bdv.tools.crop;
 
+import bdv.export.DownsampleBlock;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerState;
 import java.awt.BorderLayout;
@@ -389,7 +390,7 @@ public class CropDialog extends JDialog
 		}
 
 		final int numThreads = Math.max( 1, Runtime.getRuntime().availableProcessors() - 2 );
-		WriteSequenceToHdf5.writeHdf5File( seq, perSetupMipmapInfo, true, hdf5File, null, null, numThreads, null );
+		WriteSequenceToHdf5.writeHdf5File( seq, perSetupMipmapInfo, DownsampleBlock.DownsamplingMethod.Average, true, hdf5File, null, null, numThreads, null );
 
 		// Build ViewRegistrations with adjusted transforms.
 		final ArrayList< ViewRegistration > registrations = new ArrayList<>();


### PR DESCRIPTION
@tpietzsch 
I made the downsampling method for exporting resolution pyramids configurable and added a new method for downsampling, which picks the central pixel. This is useful for downsampling label mask images. 
