### PR TITLE
Improve suggested subsampling factors / chunk sizes for 2D images

### DIFF
--- a/src/main/java/bdv/export/ProposeMipmaps.java
+++ b/src/main/java/bdv/export/ProposeMipmaps.java
@@ -110,16 +110,6 @@ public class ProposeMipmaps
 		{
 			resolutions.add( res.clone() );
 
-			double vmax = 0;
-			int dmax = 0;
-			for ( int d = 0; d < 3; ++d )
-			{
-				if ( voxelScale[ d ] > vmax )
-				{
-					vmax = voxelScale[ d ];
-					dmax = d;
-				}
-			}
 			subdivisions.add( suggestPoTBlockSize( voxelScale, maxNumElements ) );
 
 			setup.getSize().dimensions( size );

--- a/src/main/java/bdv/export/ProposeMipmaps.java
+++ b/src/main/java/bdv/export/ProposeMipmaps.java
@@ -116,7 +116,7 @@ public class ProposeMipmaps
 			long maxSize = 0;
 			for ( int d = 0; d < 3; ++d )
 			{
-				size[ d ] /= res[ d ];
+				size[ d ] = Math.max( 1, size[ d ] / res[ d ] );
 				maxSize = Math.max( maxSize, size[ d ] );
 			}
 
@@ -132,13 +132,20 @@ public class ProposeMipmaps
 			if ( maxSize <= 256 )
 				break;
 
+			boolean anyDimensionChanged = false;
 			for ( int d = 0; d < 3; ++d )
 			{
-				if ( voxelScale[ d ] <= 2.0 )
+				if ( voxelScale[ d ] <= 2.0 && size[ d ] > 1 )
 				{
 					res[ d ] *= 2;
 					voxelScale[ d ] *= 2;
+					anyDimensionChanged = true;
 				}
+			}
+			if ( !anyDimensionChanged )
+			{
+				for ( int d = 0; d < 3; ++d )
+					res[ d ] *= 2;
 			}
 			normalizeVoxelSize( voxelScale );
 		}


### PR DESCRIPTION
This improves the algorithm for suggesting and subsampling factors / chunk sizes:

* We don't consider dimensions with size 1 for (further) downsampling
* We use the dimensions of downsampled image in chunk size determination. For example we will never suggest chunk size [16,16,16] for 2D images. Knowing that dim[Z]==1, the cell size will be limited to 1 in Z.

This should resolve https://github.com/bigdataviewer/bigdataviewer_fiji/issues/21
