### PR TITLE
AbstractViewerPanel

### DIFF
--- a/src/main/java/bdv/tools/InitializeViewerState.java
+++ b/src/main/java/bdv/tools/InitializeViewerState.java
@@ -28,10 +28,6 @@
  */
 package bdv.tools;
 
-import bdv.tools.brightness.ConverterSetup;
-import bdv.util.Bounds;
-import bdv.viewer.ConverterSetups;
-import bdv.viewer.ViewerFrame;
 import java.awt.Dimension;
 
 import net.imglib2.Interval;
@@ -40,19 +36,21 @@ import net.imglib2.histogram.DiscreteFrequencyDistribution;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.histogram.Real1dBinMapper;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.util.LinAlgHelpers;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
+import bdv.tools.brightness.ConverterSetup;
 import bdv.tools.brightness.MinMaxGroup;
 import bdv.tools.brightness.SetupAssignments;
 import bdv.util.Affine3DHelpers;
+import bdv.util.Bounds;
+import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.ConverterSetups;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.ViewerFrame;
 import bdv.viewer.ViewerState;
 
 public class InitializeViewerState
@@ -73,9 +71,9 @@ public class InitializeViewerState
 	 *            the viewer (containing at least one source) to have its
 	 *            transform set.
 	 */
-	public static void initTransform( final ViewerPanel viewer )
+	public static void initTransform( final AbstractViewerPanel viewer )
 	{
-		final Dimension dim = viewer.getDisplay().getSize();
+		final Dimension dim = viewer.getDisplayComponent().getSize();
 		final AffineTransform3D viewerTransform = initTransform( dim.width, dim.height, false, viewer.state().snapshot() );
 		viewer.state().setViewerTransform( viewerTransform );
 	}
@@ -180,7 +178,7 @@ public class InitializeViewerState
 		final Source< ? > source = current.getSpimSource();
 		final int timepoint = state.getCurrentTimepoint();
 		final Bounds bounds = estimateSourceRange( source, timepoint, cumulativeMinCutoff, cumulativeMaxCutoff );
-		for ( SourceAndConverter< ? > s : state.getSources() )
+		for ( final SourceAndConverter< ? > s : state.getSources() )
 		{
 			final ConverterSetup setup = converterSetups.getConverterSetup( s );
 			setup.setDisplayRange( bounds.getMinBound(), bounds.getMaxBound() );
@@ -241,7 +239,7 @@ public class InitializeViewerState
 	}
 
 	@Deprecated
-	public static void initBrightness( final double cumulativeMinCutoff, final double cumulativeMaxCutoff, final ViewerPanel viewer, final SetupAssignments setupAssignments )
+	public static void initBrightness( final double cumulativeMinCutoff, final double cumulativeMaxCutoff, final AbstractViewerPanel viewer, final SetupAssignments setupAssignments )
 	{
 		initBrightness( cumulativeMinCutoff, cumulativeMaxCutoff, viewer.state().snapshot(), setupAssignments );
 	}

--- a/src/main/java/bdv/tools/bookmarks/BookmarkTextOverlayAnimator.java
+++ b/src/main/java/bdv/tools/bookmarks/BookmarkTextOverlayAnimator.java
@@ -35,7 +35,7 @@ import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
 import java.awt.geom.Rectangle2D;
 
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.animate.AbstractAnimator;
 import bdv.viewer.animate.OverlayAnimator;
 
@@ -57,14 +57,14 @@ public class BookmarkTextOverlayAnimator implements OverlayAnimator
 
 	private boolean complete = false;
 
-	private final ViewerPanel viewer;
+	private final AbstractViewerPanel viewer;
 
-	public BookmarkTextOverlayAnimator( final ViewerPanel viewer )
+	public BookmarkTextOverlayAnimator( final AbstractViewerPanel viewer )
 	{
 		this( viewer, new Font( "SansSerif", Font.BOLD, 20 ) );
 	}
 
-	public BookmarkTextOverlayAnimator( final ViewerPanel viewer, final Font font )
+	public BookmarkTextOverlayAnimator( final AbstractViewerPanel viewer, final Font font )
 	{
 		this.viewer = viewer;
 		this.font = font;
@@ -75,7 +75,7 @@ public class BookmarkTextOverlayAnimator implements OverlayAnimator
 		text = message;
 		animator = ( fadeInDuration > 0 ) ? new AbstractAnimator( fadeInDuration ) : null;
 		fadeIn = true;
-		viewer.getDisplay().repaint();
+		viewer.getDisplayComponent().repaint();
 	}
 
 	public final void fadeOut( final String message, final long fadeOutDuration )
@@ -83,7 +83,7 @@ public class BookmarkTextOverlayAnimator implements OverlayAnimator
 		text = message;
 		animator = new AbstractAnimator( fadeOutDuration );
 		fadeIn = false;
-		viewer.getDisplay().repaint();
+		viewer.getDisplayComponent().repaint();
 	}
 
 	public final void clear()
@@ -91,7 +91,7 @@ public class BookmarkTextOverlayAnimator implements OverlayAnimator
 		text = null;
 		animator = null;
 		complete = true;
-		viewer.getDisplay().repaint();
+		viewer.getDisplayComponent().repaint();
 	}
 
 	@Override

--- a/src/main/java/bdv/tools/bookmarks/BookmarksEditor.java
+++ b/src/main/java/bdv/tools/bookmarks/BookmarksEditor.java
@@ -41,14 +41,15 @@ import javax.swing.ActionMap;
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
 
+import net.imglib2.Point;
+import net.imglib2.realtransform.AffineTransform3D;
+
 import org.scijava.ui.behaviour.util.InputActionBindings;
 
 import bdv.util.Affine3DHelpers;
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.animate.RotationAnimator;
 import bdv.viewer.animate.SimilarityTransformAnimator;
-import net.imglib2.Point;
-import net.imglib2.realtransform.AffineTransform3D;
 
 public class BookmarksEditor
 {
@@ -66,7 +67,7 @@ public class BookmarksEditor
 
 	private final ArrayList< String  > inputMapsToBlock;
 
-	private final ViewerPanel viewer;
+	private final AbstractViewerPanel viewer;
 
 	private final InputActionBindings bindings;
 
@@ -76,7 +77,7 @@ public class BookmarksEditor
 
 	private BookmarkTextOverlayAnimator animator;
 
-	public BookmarksEditor( final ViewerPanel viewer, final InputActionBindings inputActionBindings, final Bookmarks bookmarks )
+	public BookmarksEditor( final AbstractViewerPanel viewer, final InputActionBindings inputActionBindings, final Bookmarks bookmarks )
 	{
 		this.viewer = viewer;
 		bindings = inputActionBindings;
@@ -99,7 +100,7 @@ public class BookmarksEditor
 		inputMap.put( abortKey, "abort bookmark" );
 		bindings.addActionMap( "bookmarks", actionMap );
 
-		viewer.getDisplay().addKeyListener( new KeyAdapter()
+		viewer.getDisplayComponent().addKeyListener( new KeyAdapter()
 		{
 			@Override
 			public void keyTyped( final KeyEvent e )
@@ -117,8 +118,8 @@ public class BookmarksEditor
 						{
 							final AffineTransform3D t = new AffineTransform3D();
 							viewer.state().getViewerTransform( t );
-							final double cX = viewer.getDisplay().getWidth() / 2.0;
-							final double cY = viewer.getDisplay().getHeight() / 2.0;
+							final double cX = viewer.getDisplayComponent().getWidth() / 2.0;
+							final double cY = viewer.getDisplayComponent().getHeight() / 2.0;
 							t.set( t.get( 0, 3 ) - cX, 0, 3 );
 							t.set( t.get( 1, 3 ) - cY, 1, 3 );
 							bookmarks.put( key, t );
@@ -133,8 +134,8 @@ public class BookmarksEditor
 							{
 								final AffineTransform3D c = new AffineTransform3D();
 								viewer.state().getViewerTransform( c );
-								final double cX = viewer.getDisplay().getWidth() / 2.0;
-								final double cY = viewer.getDisplay().getHeight() / 2.0;
+								final double cX = viewer.getDisplayComponent().getWidth() / 2.0;
+								final double cY = viewer.getDisplayComponent().getHeight() / 2.0;
 								c.set( c.get( 0, 3 ) - cX, 0, 3 );
 								c.set( c.get( 1, 3 ) - cY, 1, 3 );
 								viewer.setTransformAnimator( new SimilarityTransformAnimator( c, t, cX, cY, 300 ) );

--- a/src/main/java/bdv/tools/boundingbox/AbstractTransformedBoxSelectionDialog.java
+++ b/src/main/java/bdv/tools/boundingbox/AbstractTransformedBoxSelectionDialog.java
@@ -50,7 +50,7 @@ import bdv.tools.boundingbox.BoxSelectionOptions.TimepointSelection;
 import bdv.tools.brightness.SliderPanel;
 import bdv.util.BoundedInterval;
 import bdv.util.BoundedValue;
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
 
 /**
  * @author Tobias Pietzsch
@@ -153,7 +153,7 @@ public abstract class AbstractTransformedBoxSelectionDialog< R > extends JDialog
 
 		final TimepointSelection mode;
 
-		public TimepointSelectionPanel( final ViewerPanel viewer, final BoxSelectionOptions options )
+		public TimepointSelectionPanel( final AbstractViewerPanel viewer, final BoxSelectionOptions options )
 		{
 			setLayout( new BoxLayout( this, BoxLayout.PAGE_AXIS ) );
 

--- a/src/main/java/bdv/tools/boundingbox/TransformedBoxEditor.java
+++ b/src/main/java/bdv/tools/boundingbox/TransformedBoxEditor.java
@@ -30,7 +30,7 @@ package bdv.tools.boundingbox;
 
 import static bdv.tools.boundingbox.TransformedBoxOverlay.BoxDisplayMode.FULL;
 
-import bdv.viewer.ConverterSetups;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -45,7 +45,8 @@ import org.scijava.ui.behaviour.util.Behaviours;
 import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
 import bdv.tools.boundingbox.TransformedBoxOverlay.BoxDisplayMode;
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.ConverterSetups;
 
 /**
  * Installs an interactive box selection tool on a BDV.
@@ -74,7 +75,7 @@ public class TransformedBoxEditor
 
 	private final TransformedBoxOverlaySource boxSource;
 
-	private final ViewerPanel viewer;
+	private final AbstractViewerPanel viewer;
 
 	private final TriggerBehaviourBindings triggerbindings;
 
@@ -92,7 +93,7 @@ public class TransformedBoxEditor
 
 	public TransformedBoxEditor(
 			final InputTriggerConfig keyconf,
-			final ViewerPanel viewer,
+			final AbstractViewerPanel viewer,
 			final ConverterSetups converterSetups,
 			final int setupId,
 			final TriggerBehaviourBindings triggerbindings,
@@ -103,7 +104,7 @@ public class TransformedBoxEditor
 
 	public TransformedBoxEditor(
 			final InputTriggerConfig keyconf,
-			final ViewerPanel viewer,
+			final AbstractViewerPanel viewer,
 			final ConverterSetups converterSetups,
 			final int setupId,
 			final TriggerBehaviourBindings triggerbindings,
@@ -169,7 +170,7 @@ public class TransformedBoxEditor
 	public void uninstall()
 	{
 		viewer.getDisplay().overlays().remove( boxOverlay );
-		viewer.removeTransformListener( boxOverlay );
+		viewer.renderTransformListeners().remove( boxOverlay );
 		viewer.getDisplay().removeHandler( boxOverlay.getCornerHighlighter() );
 
 		triggerbindings.removeInputTriggerMap( BOUNDING_BOX_MAP );
@@ -281,7 +282,7 @@ public class TransformedBoxEditor
 		final Map< InputTrigger, Set< String > > bindings = triggerbindings.getConcatenatedInputTriggerMap().getAllBindings();
 		final Set< String > behavioursToBlock = new HashSet<>();
 		for ( final InputTrigger t : moveCornerTriggers )
-			behavioursToBlock.addAll( bindings.get( t ) );
+			behavioursToBlock.addAll( bindings.getOrDefault( t, Collections.emptySet() ) );
 
 		blockMap.clear();
 		final Behaviour block = new Behaviour() {};

--- a/src/main/java/bdv/tools/boundingbox/TransformedBoxOverlaySource.java
+++ b/src/main/java/bdv/tools/boundingbox/TransformedBoxOverlaySource.java
@@ -28,19 +28,21 @@
  */
 package bdv.tools.boundingbox;
 
+import static bdv.viewer.ViewerStateChange.VISIBILITY_CHANGED;
+
+import java.awt.Color;
+
+import net.imglib2.type.numeric.ARGBType;
+
 import bdv.util.Bounds;
 import bdv.util.PlaceHolderConverterSetup;
+import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.ConverterSetups;
 import bdv.viewer.DisplayMode;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerPanel;
 import bdv.viewer.ViewerState;
 import bdv.viewer.ViewerStateChange;
 import bdv.viewer.ViewerStateChangeListener;
-import java.awt.Color;
-import net.imglib2.type.numeric.ARGBType;
-
-import static bdv.viewer.ViewerStateChange.VISIBILITY_CHANGED;
 
 /**
  * A BDV source (and converter etc) representing a {@code TransformedBox}.
@@ -59,7 +61,7 @@ public class TransformedBoxOverlaySource
 
 	private final SourceAndConverter< Void > boxSourceAndConverter;
 
-	private final ViewerPanel viewer;
+	private final AbstractViewerPanel viewer;
 
 	private final ConverterSetups setups;
 
@@ -69,7 +71,7 @@ public class TransformedBoxOverlaySource
 			final String name,
 			final TransformedBoxOverlay boxOverlay,
 			final TransformedBox bbSource,
-			final ViewerPanel viewer,
+			final AbstractViewerPanel viewer,
 			final ConverterSetups converterSetups,
 			final int setupId )
 	{
@@ -92,7 +94,7 @@ public class TransformedBoxOverlaySource
 		{
 			if ( state.getDisplayMode() != DisplayMode.FUSED )
 			{
-				for ( SourceAndConverter< ? > source : state.getSources() )
+				for ( final SourceAndConverter< ? > source : state.getSources() )
 					state.setSourceActive( source, state.isSourceVisible( source ) );
 				state.setDisplayMode( DisplayMode.FUSED );
 			}
@@ -140,6 +142,6 @@ public class TransformedBoxOverlaySource
 			final int argb = ( boxConverterSetup.getColor().get() & 0x00ffffff ) | ( alpha << 24 );
 			boxOverlay.setIntersectionFillColor( new Color( argb, true ) );
 		}
-		viewer.getDisplay().repaint();
+		viewer.getDisplayComponent().repaint();
 	}
 }

--- a/src/main/java/bdv/tools/boundingbox/TransformedBoxSelectionDialog.java
+++ b/src/main/java/bdv/tools/boundingbox/TransformedBoxSelectionDialog.java
@@ -30,7 +30,6 @@ package bdv.tools.boundingbox;
 
 import static bdv.tools.boundingbox.BoxSelectionOptions.TimepointSelection.NONE;
 
-import bdv.viewer.ConverterSetups;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -52,7 +51,8 @@ import net.imglib2.realtransform.AffineTransform3D;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.ConverterSetups;
 
 /**
  * @author Tobias Pietzsch
@@ -68,7 +68,7 @@ public class TransformedBoxSelectionDialog extends AbstractTransformedBoxSelecti
 
 	protected final JPanel content;
 
-	protected final ViewerPanel viewer;
+	protected final AbstractViewerPanel viewer;
 
 	protected final BoxSelectionPanel boxSelectionPanel;
 
@@ -77,7 +77,7 @@ public class TransformedBoxSelectionDialog extends AbstractTransformedBoxSelecti
 	protected final BoxSelectionOptions options;
 
 	public TransformedBoxSelectionDialog(
-			final ViewerPanel viewer,
+			final AbstractViewerPanel viewer,
 			final ConverterSetups converterSetups,
 			final int setupId,
 			final InputTriggerConfig keyConfig,
@@ -136,7 +136,7 @@ public class TransformedBoxSelectionDialog extends AbstractTransformedBoxSelecti
 		} );
 		model.intervalChangedListeners().add( () -> {
 			boxSelectionPanel.updateSliders( model.box().getInterval() );
-			viewer.getDisplay().repaint();
+			viewer.getDisplayComponent().repaint();
 		} );
 	}
 

--- a/src/main/java/bdv/tools/boundingbox/TransformedRealBoxSelectionDialog.java
+++ b/src/main/java/bdv/tools/boundingbox/TransformedRealBoxSelectionDialog.java
@@ -30,7 +30,6 @@ package bdv.tools.boundingbox;
 
 import static bdv.tools.boundingbox.BoxSelectionOptions.TimepointSelection.NONE;
 
-import bdv.viewer.ConverterSetups;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -55,7 +54,8 @@ import net.imglib2.util.Intervals;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.ConverterSetups;
 
 /**
  * @author Tobias Pietzsch
@@ -71,7 +71,7 @@ public class TransformedRealBoxSelectionDialog extends AbstractTransformedBoxSel
 
 	protected final JPanel content;
 
-	protected final ViewerPanel viewer;
+	protected final AbstractViewerPanel viewer;
 
 	protected final RealBoxSelectionPanel boxSelectionPanel;
 
@@ -80,7 +80,7 @@ public class TransformedRealBoxSelectionDialog extends AbstractTransformedBoxSel
 	protected final BoxSelectionOptions options;
 
 	public TransformedRealBoxSelectionDialog(
-			final ViewerPanel viewer,
+			final AbstractViewerPanel viewer,
 			final ConverterSetups converterSetups,
 			final int setupId,
 			final InputTriggerConfig keyConfig,
@@ -139,7 +139,7 @@ public class TransformedRealBoxSelectionDialog extends AbstractTransformedBoxSel
 		} );
 		model.intervalChangedListeners().add( () -> {
 			boxSelectionPanel.updateSliders( model.getInterval() );
-			viewer.getDisplay().repaint();
+			viewer.getDisplayComponent().repaint();
 		} );
 	}
 

--- a/src/main/java/bdv/tools/transformation/ManualTransformation.java
+++ b/src/main/java/bdv/tools/transformation/ManualTransformation.java
@@ -28,23 +28,23 @@
  */
 package bdv.tools.transformation;
 
-import bdv.viewer.SynchronizedViewerState;
-import bdv.viewer.ViewerState;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.imglib2.realtransform.AffineTransform3D;
+
 import org.jdom2.Element;
 
+import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerPanel;
-import net.imglib2.realtransform.AffineTransform3D;
+import bdv.viewer.ViewerState;
 
 public class ManualTransformation
 {
 	private final XmlIoTransformedSources io;
 
-	private final ViewerPanel viewer;
+	private final AbstractViewerPanel viewer;
 
 	private final List< SourceAndConverter< ? > > sources;
 
@@ -55,7 +55,7 @@ public class ManualTransformation
 		io = new XmlIoTransformedSources();
 	}
 
-	public ManualTransformation( final ViewerPanel viewer )
+	public ManualTransformation( final AbstractViewerPanel viewer )
 	{
 		this.viewer = viewer;
 		this.sources = null;

--- a/src/main/java/bdv/tools/transformation/ManualTransformationEditor.java
+++ b/src/main/java/bdv/tools/transformation/ManualTransformationEditor.java
@@ -28,21 +28,26 @@
  */
 package bdv.tools.transformation;
 
-import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerPanel;
-import bdv.viewer.ViewerState;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+
 import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
+
 import net.imglib2.realtransform.AffineTransform3D;
-import bdv.viewer.TransformListener;
+
 import org.scijava.listeners.Listeners;
 import org.scijava.ui.behaviour.util.InputActionBindings;
 import org.scijava.ui.behaviour.util.RunnableAction;
+
+import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.TransformListener;
+import bdv.viewer.ViewerState;
 
 // TODO: what happens when the current source, display mode, etc is changed while the editor is active? deactivate?
 public class ManualTransformationEditor implements TransformListener< AffineTransform3D >
@@ -50,8 +55,6 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 	private boolean active = false;
 
 	private final InputActionBindings bindings;
-
-	private final ViewerPanel viewer;
 
 	private final AffineTransform3D frozenTransform;
 
@@ -67,9 +70,37 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 
 	private final Listeners.List< ManualTransformActiveListener > manualTransformActiveListeners;
 
-	public ManualTransformationEditor( final ViewerPanel viewer, final InputActionBindings inputActionBindings )
+	private final Listeners< TransformListener< AffineTransform3D > > viewerTransformListeners;
+
+	private final ViewerState viewerState;
+
+	private final Consumer< String > viewerMessageDisplay;
+
+	public ManualTransformationEditor( final AbstractViewerPanel viewer, final InputActionBindings inputActionBindings )
 	{
-		this.viewer = viewer;
+		this( viewer.transformListeners(), viewer.state(), viewer::showMessage, inputActionBindings );
+	}
+
+	/**
+	 * @param viewerTransformListeners
+	 * 		the editor will register here for listening to transform changes while active
+	 * @param viewerState
+	 * 		the state which is manipulated by the editor
+	 * @param viewerMessageDisplay
+	 * 		messages will be displayed here
+	 * @param inputActionBindings
+	 * 		the editors actionMap will be registered here while active
+	 */
+	public ManualTransformationEditor(
+			final Listeners< TransformListener< AffineTransform3D > > viewerTransformListeners,
+			final ViewerState viewerState,
+			final Consumer< String > viewerMessageDisplay,
+			final InputActionBindings inputActionBindings )
+	{
+		this.viewerTransformListeners = viewerTransformListeners;
+		this.viewerState = viewerState;
+		this.viewerMessageDisplay = viewerMessageDisplay;
+
 		bindings = inputActionBindings;
 		frozenTransform = new AffineTransform3D();
 		liveTransform = new AffineTransform3D();
@@ -97,8 +128,8 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 			final AffineTransform3D identity = new AffineTransform3D();
 			for ( final TransformedSource< ? > source : sourcesToModify )
 				source.setIncrementalTransform( identity );
-			viewer.state().setViewerTransform( frozenTransform );
-			viewer.showMessage( "aborted manual transform" );
+			viewerState.setViewerTransform( frozenTransform );
+			viewerMessageDisplay.accept( "aborted manual transform" );
 			active = false;
 			manualTransformActiveListeners.list.forEach( l -> l.manualTransformActiveChanged( active ) );
 		}
@@ -118,8 +149,8 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 			{
 				source.setIncrementalTransform( identity );
 			}
-			viewer.state().setViewerTransform( frozenTransform );
-			viewer.showMessage( "reset manual transform" );
+			viewerState.setViewerTransform( frozenTransform );
+			viewerMessageDisplay.accept( "reset manual transform" );
 		}
 	}
 
@@ -131,7 +162,7 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 		if ( a )
 		{
 			// Enter manual edit mode
-			final ViewerState state = viewer.state().snapshot();
+			final ViewerState state = this.viewerState.snapshot();
 			final List< SourceAndConverter< ? > > currentSources = new ArrayList<>();
 			switch ( state.getDisplayMode() )
 			{
@@ -142,13 +173,13 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 				currentSources.addAll( state.getSourcesInGroup( state.getCurrentGroup() ) );
 				break;
 			default:
-				viewer.showMessage( "Can only do manual transformation when in FUSED mode." );
+				viewerMessageDisplay.accept( "Can only do manual transformation when in FUSED mode." );
 				return;
 			}
 			state.getViewerTransform( frozenTransform );
 			sourcesToModify.clear();
 			sourcesToFix.clear();
-			for ( SourceAndConverter< ? > source : state.getSources() )
+			for ( final SourceAndConverter< ? > source : state.getSources() )
 			{
 				if ( source.getSpimSource() instanceof TransformedSource )
 				{
@@ -159,15 +190,15 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 				}
 			}
 			active = true;
-			viewer.addTransformListener( this );
+			viewerTransformListeners.add( this );
 			bindings.addInputMap( "manual transform", inputMap );
-			viewer.showMessage( "starting manual transform" );
+			viewerMessageDisplay.accept( "starting manual transform" );
 		}
 		else
 		{
 			// Exit manual edit mode.
 			active = false;
-			viewer.removeTransformListener( this );
+			viewerTransformListeners.remove( this );
 			bindings.removeInputMap( "manual transform" );
 			final AffineTransform3D tmp = new AffineTransform3D();
 			for ( final TransformedSource< ? > source : sourcesToModify )
@@ -181,8 +212,8 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 			tmp.identity();
 			for ( final TransformedSource< ? > source : sourcesToFix )
 				source.setIncrementalTransform( tmp );
-			viewer.state().setViewerTransform( frozenTransform );
-			viewer.showMessage( "fixed manual transform" );
+			viewerState.setViewerTransform( frozenTransform );
+			viewerMessageDisplay.accept( "fixed manual transform" );
 		}
 		manualTransformActiveListeners.list.forEach( l -> l.manualTransformActiveChanged( active ) );
 	}
@@ -195,7 +226,10 @@ public class ManualTransformationEditor implements TransformListener< AffineTran
 	@Override
 	public void transformChanged( final AffineTransform3D transform )
 	{
-		if ( !active ) { return; }
+		if ( !active )
+		{
+			return;
+		}
 
 		liveTransform.set( transform );
 		liveTransform.preConcatenate( frozenTransform.inverse() );

--- a/src/main/java/bdv/ui/BdvDefaultCards.java
+++ b/src/main/java/bdv/ui/BdvDefaultCards.java
@@ -28,13 +28,6 @@
  */
 package bdv.ui;
 
-import bdv.ui.convertersetupeditor.ConverterSetupEditPanel;
-import bdv.ui.sourcegrouptree.SourceGroupTree;
-import bdv.ui.sourcetable.SourceTable;
-import bdv.ui.viewermodepanel.DisplaySettingsPanel;
-import bdv.viewer.ConverterSetups;
-import bdv.viewer.SynchronizedViewerState;
-import bdv.viewer.ViewerPanel;
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Dimension;
@@ -43,11 +36,20 @@ import java.awt.KeyboardFocusManager;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.WeakReference;
+
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.border.EmptyBorder;
 import javax.swing.tree.TreeSelectionModel;
+
+import bdv.ui.convertersetupeditor.ConverterSetupEditPanel;
+import bdv.ui.sourcegrouptree.SourceGroupTree;
+import bdv.ui.sourcetable.SourceTable;
+import bdv.ui.viewermodepanel.DisplaySettingsPanel;
+import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.ConverterSetups;
+import bdv.viewer.ViewerState;
 
 /**
  * Default cards added to the card panel.
@@ -67,12 +69,12 @@ public class BdvDefaultCards
 
 	public static final String DEFAULT_VIEWERMODES_CARD = "default bdv viewer modes card";
 
-	public static void setup( final CardPanel cards, final ViewerPanel viewer, final ConverterSetups converterSetups )
+	public static void setup( final CardPanel cards, final AbstractViewerPanel viewer, final ConverterSetups converterSetups )
 	{
-		final SynchronizedViewerState state = viewer.state();
+		final ViewerState state = viewer.state();
 
 		// -- Sources table --
-		final SourceTable table = new SourceTable( state, converterSetups, viewer.getOptionValues().getInputTriggerConfig() );
+		final SourceTable table = new SourceTable( state, converterSetups, viewer.getInputTriggerConfig() );
 		table.setPreferredScrollableViewportSize( new Dimension( 300, 200 ) );
 		table.setFillsViewportHeight( true );
 		table.setDragEnabled( true );
@@ -86,7 +88,7 @@ public class BdvDefaultCards
 		tablePanel.setPreferredSize( new Dimension( 300, 245 ) );
 
 		// -- Groups tree --
-		final SourceGroupTree tree = new SourceGroupTree( state, viewer.getOptionValues().getInputTriggerConfig() );
+		final SourceGroupTree tree = new SourceGroupTree( state, viewer.getInputTriggerConfig() );
 //		tree.setPreferredSize( new Dimension( 300, 200 ) );
 		tree.setVisibleRowCount( 10 );
 		tree.setEditable( true );

--- a/src/main/java/bdv/ui/splitpanel/SplitPaneOneTouchExpandTrigger.java
+++ b/src/main/java/bdv/ui/splitpanel/SplitPaneOneTouchExpandTrigger.java
@@ -28,15 +28,16 @@
  */
 package bdv.ui.splitpanel;
 
-import bdv.ui.splitpanel.SplitPaneOneTouchExpandAnimator.AnimationType;
-import bdv.viewer.ViewerPanel;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-
 import static bdv.ui.splitpanel.SplitPaneOneTouchExpandAnimator.AnimationType.HIDE_COLLAPSE;
 import static bdv.ui.splitpanel.SplitPaneOneTouchExpandAnimator.AnimationType.HIDE_EXPAND;
 import static bdv.ui.splitpanel.SplitPaneOneTouchExpandAnimator.AnimationType.SHOW_COLLAPSE;
 import static bdv.ui.splitpanel.SplitPaneOneTouchExpandAnimator.AnimationType.SHOW_EXPAND;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import bdv.ui.splitpanel.SplitPaneOneTouchExpandAnimator.AnimationType;
+import bdv.viewer.AbstractViewerPanel;
 
 class SplitPaneOneTouchExpandTrigger extends MouseAdapter
 {
@@ -44,9 +45,9 @@ class SplitPaneOneTouchExpandTrigger extends MouseAdapter
 
 	private final SplitPanel splitPanel;
 
-	private final ViewerPanel viewer;
+	private final AbstractViewerPanel viewer;
 
-	public SplitPaneOneTouchExpandTrigger( final SplitPaneOneTouchExpandAnimator animator, final SplitPanel splitPanel, final ViewerPanel viewer )
+	public SplitPaneOneTouchExpandTrigger( final SplitPaneOneTouchExpandAnimator animator, final SplitPanel splitPanel, final AbstractViewerPanel viewer )
 	{
 		this.animator = animator;
 		this.splitPanel = splitPanel;
@@ -137,6 +138,6 @@ class SplitPaneOneTouchExpandTrigger extends MouseAdapter
 	private void startAnimation( final AnimationType animationType )
 	{
 		animator.startAnimation( animationType );
-		viewer.getDisplay().repaint();
+		viewer.getDisplayComponent().repaint();
 	}
 }

--- a/src/main/java/bdv/ui/splitpanel/SplitPanel.java
+++ b/src/main/java/bdv/ui/splitpanel/SplitPanel.java
@@ -28,13 +28,12 @@
  */
 package bdv.ui.splitpanel;
 
-import bdv.ui.CardPanel;
-import bdv.viewer.ViewerPanel;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+
 import javax.swing.InputMap;
 import javax.swing.JComponent;
 import javax.swing.JScrollPane;
@@ -44,8 +43,12 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.basic.BasicSplitPaneDivider;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
+
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 import org.scijava.ui.behaviour.util.Actions;
+
+import bdv.ui.CardPanel;
+import bdv.viewer.AbstractViewerPanel;
 
 /**
  * A {@code JSplitPane} with a {@code ViewerPanel} on the left and a
@@ -70,7 +73,7 @@ public class SplitPanel extends JSplitPane
 
 	private final SplitPaneOneTouchExpandAnimator oneTouchExpandAnimator;
 
-	public SplitPanel( final ViewerPanel viewerPanel, final CardPanel cardPanel )
+	public SplitPanel( final AbstractViewerPanel viewerPanel, final CardPanel cardPanel )
 	{
 		super( JSplitPane.HORIZONTAL_SPLIT );
 
@@ -85,7 +88,7 @@ public class SplitPanel extends JSplitPane
 		final InputMap inputMap = scrollPane.getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
 		inputMap.put( KeyStroke.getKeyStroke( "F6" ), "none" );
 
-		final InputTriggerConfig inputTriggerConfig = viewerPanel.getOptionValues().getInputTriggerConfig();
+		final InputTriggerConfig inputTriggerConfig = viewerPanel.getInputTriggerConfig();
 		final Actions actions = new Actions( inputMap, scrollPane.getActionMap(), inputTriggerConfig, "bdv" );
 		actions.runnableAction( viewerPanel::requestFocusInWindow, FOCUS_VIEWER_PANEL, "ESCAPE" );
 		actions.runnableAction( () -> {
@@ -104,8 +107,8 @@ public class SplitPanel extends JSplitPane
 		viewerPanel.addOverlayAnimator( oneTouchExpandAnimator );
 
 		final SplitPaneOneTouchExpandTrigger oneTouchExpandTrigger = new SplitPaneOneTouchExpandTrigger( oneTouchExpandAnimator, this, viewerPanel );
-		viewerPanel.getDisplay().addMouseMotionListener( oneTouchExpandTrigger );
-		viewerPanel.getDisplay().addMouseListener( oneTouchExpandTrigger );
+		viewerPanel.getDisplayComponent().addMouseMotionListener( oneTouchExpandTrigger );
+		viewerPanel.getDisplayComponent().addMouseListener( oneTouchExpandTrigger );
 
 		setDividerSize( DEFAULT_DIVIDER_SIZE );
 

--- a/src/main/java/bdv/viewer/AbstractViewerPanel.java
+++ b/src/main/java/bdv/viewer/AbstractViewerPanel.java
@@ -148,7 +148,7 @@ public abstract class AbstractViewerPanel extends JPanel implements RequestRepai
 	 * @param plane
 	 *            to which plane to align.
 	 */
-	protected void align( final AlignPlane plane )
+	public void align( final AlignPlane plane )
 	{
 		final Source< ? > source = state().getCurrentSource().getSpimSource();
 		final AffineTransform3D sourceTransform = new AffineTransform3D();

--- a/src/main/java/bdv/viewer/AbstractViewerPanel.java
+++ b/src/main/java/bdv/viewer/AbstractViewerPanel.java
@@ -1,0 +1,289 @@
+package bdv.viewer;
+
+import java.awt.Component;
+import java.awt.LayoutManager;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+
+import javax.swing.JPanel;
+
+import net.imglib2.Positionable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.util.LinAlgHelpers;
+
+import org.scijava.listeners.Listeners;
+import org.scijava.ui.behaviour.io.InputTriggerConfig;
+
+import bdv.util.Affine3DHelpers;
+import bdv.viewer.animate.AbstractTransformAnimator;
+import bdv.viewer.animate.OverlayAnimator;
+import bdv.viewer.animate.RotationAnimator;
+
+/**
+ * Abstract base class for {@link ViewerPanel}. It mostly serves as an interface
+ * for tools like {@code BookmarksEditor}, to abstract from the specific {@code
+ * ViewerPanel} implementation. (This allows for re-using these tools in
+ * BigVolumeViewer.)
+ *
+ * @author Tobias Pietzsch
+ */
+public abstract class AbstractViewerPanel extends JPanel implements RequestRepaint
+{
+	/**
+	 * Keeps track of the current mouse coordinates, which are used to provide
+	 * the current global position (see {@link #getGlobalMouseCoordinates(RealPositionable)}).
+	 */
+	protected final MouseCoordinateListener mouseCoordinates;
+
+	public AbstractViewerPanel( final LayoutManager layout, final boolean isDoubleBuffered )
+	{
+		super( layout, isDoubleBuffered );
+		mouseCoordinates = new MouseCoordinateListener();
+	}
+
+	public AbstractViewerPanel( final LayoutManager layout )
+	{
+		this( layout, true );
+	}
+
+	public abstract InputTriggerConfig getInputTriggerConfig();
+
+	/**
+	 * Get the viewer canvas.
+	 *
+	 * @return the viewer canvas.
+	 */
+	public abstract InteractiveDisplay getDisplay();
+
+	/**
+	 * Get the AWT {@code Component} of the viewer canvas.
+	 *
+	 * @return the viewer canvas.
+	 */
+	public abstract Component getDisplayComponent();
+
+	/**
+	 * Add a new {@link OverlayAnimator} to the list of animators. The animation
+	 * is immediately started. The new {@link OverlayAnimator} will remain in
+	 * the list of animators until it {@link OverlayAnimator#isComplete()}.
+	 *
+	 * @param animator
+	 *            animator to add.
+	 */
+	public abstract void addOverlayAnimator( OverlayAnimator animator );
+
+	/**
+	 * Get the ViewerState. This can be directly used for modifications, e.g.,
+	 * adding/removing sources etc. See {@link SynchronizedViewerState} for
+	 * thread-safety considerations.
+	 */
+	public abstract ViewerState state();
+
+	/**
+	 * Add/remove {@code TransformListener}s to notify about viewer transformation
+	 * changes. Listeners will be notified when a new image has been painted
+	 * with the viewer transform used to render that image.
+	 * <p>
+	 * This happens immediately after that image is painted onto the screen,
+	 * before any overlays are painted.
+	 */
+	public abstract Listeners< TransformListener< AffineTransform3D > > renderTransformListeners();
+
+	/**
+	 * Add/remove {@code TransformListener}s to notify about viewer transformation
+	 * changes. Listeners will be notified <em>before</em> calling
+	 * {@link #requestRepaint()} so they have the chance to interfere.
+	 */
+	public abstract Listeners< TransformListener< AffineTransform3D > > transformListeners();
+
+	public abstract void setTransformAnimator( AbstractTransformAnimator animator );
+
+	/**
+	 * Display the specified message in a text overlay for a short time.
+	 *
+	 * @param msg
+	 *            String to display. Should be just one line of text.
+	 */
+	public abstract void showMessage( String msg );
+
+	private final static double c = Math.cos( Math.PI / 4 );
+
+	/**
+	 * The planes which can be aligned with the viewer coordinate system: XY,
+	 * ZY, and XZ plane.
+	 */
+	public enum AlignPlane
+	{
+		XY( 2, new double[] { 1, 0, 0, 0 } ),
+		ZY( 0, new double[] { c, 0, -c, 0 } ),
+		XZ( 1, new double[] { c, c, 0, 0 } );
+
+		/**
+		 * rotation from the xy-plane aligned coordinate system to this plane.
+		 */
+		public final double[] qAlign; // TODO: should be private/package private
+
+		/**
+		 * Axis index. The plane spanned by the remaining two axes will be
+		 * transformed to the same plane by the computed rotation and the
+		 * "rotation part" of the affine source transform.
+		 * @see Affine3DHelpers#extractApproximateRotationAffine(AffineTransform3D, double[], int)
+		 */
+		public final int coerceAffineDimension; // TODO: should be private/package private
+
+		private AlignPlane( final int coerceAffineDimension, final double[] qAlign )
+		{
+			this.coerceAffineDimension = coerceAffineDimension;
+			this.qAlign = qAlign;
+		}
+	}
+
+	/**
+	 * Align the XY, ZY, or XZ plane of the local coordinate system of the
+	 * currently active source with the viewer coordinate system.
+	 *
+	 * @param plane
+	 *            to which plane to align.
+	 */
+	protected void align( final AlignPlane plane )
+	{
+		final Source< ? > source = state().getCurrentSource().getSpimSource();
+		final AffineTransform3D sourceTransform = new AffineTransform3D();
+		source.getSourceTransform( state().getCurrentTimepoint(), 0, sourceTransform );
+
+		final double[] qSource = new double[ 4 ];
+		Affine3DHelpers.extractRotationAnisotropic( sourceTransform, qSource );
+
+		final double[] qTmpSource = new double[ 4 ];
+		Affine3DHelpers.extractApproximateRotationAffine( sourceTransform, qSource, plane.coerceAffineDimension );
+		LinAlgHelpers.quaternionMultiply( qSource, plane.qAlign, qTmpSource );
+
+		final double[] qTarget = new double[ 4 ];
+		LinAlgHelpers.quaternionInvert( qTmpSource, qTarget );
+
+		final AffineTransform3D transform = state().getViewerTransform();
+		final double centerX;
+		final double centerY;
+		synchronized ( mouseCoordinates )
+		{
+			if ( mouseCoordinates.isMouseInsidePanel() )
+			{
+				centerX = mouseCoordinates.getX();
+				centerY = mouseCoordinates.getY();
+			}
+			else
+			{
+				centerY = getDisplayComponent().getHeight() / 2.0;
+				centerX = getDisplayComponent().getWidth() / 2.0;
+			}
+		}
+		setTransformAnimator( new RotationAnimator( transform, centerX, centerY, qTarget, 300 ) );
+	}
+
+	/**
+	 * Set {@code gPos} to the current mouse coordinates transformed into the
+	 * global coordinate system.
+	 *
+	 * @param gPos
+	 *            is set to the current global coordinates.
+	 */
+	public void getGlobalMouseCoordinates( final RealPositionable gPos )
+	{
+		assert gPos.numDimensions() == 3;
+		final RealPoint lPos = new RealPoint( 3 );
+		mouseCoordinates.getMouseCoordinates( lPos );
+		state().getViewerTransform().applyInverse( gPos, lPos );
+	}
+
+	/**
+	 * Set {@code p} to the current mouse coordinates wrt to the display component.
+	 *
+	 * @param p
+	 *            is set to the current mouse coordinates.
+	 */
+	public void getMouseCoordinates( final Positionable p )
+	{
+		assert p.numDimensions() == 2;
+		mouseCoordinates.getMouseCoordinates( p );
+	}
+
+	protected void onMouseMoved() {}
+
+	protected class MouseCoordinateListener implements MouseMotionListener, MouseListener
+	{
+		private int x;
+
+		private int y;
+
+		private boolean isInside;
+
+		public synchronized void getMouseCoordinates( final Positionable p )
+		{
+			p.setPosition( x, 0 );
+			p.setPosition( y, 1 );
+		}
+
+		@Override
+		public synchronized void mouseDragged( final MouseEvent e )
+		{
+			x = e.getX();
+			y = e.getY();
+		}
+
+		@Override
+		public synchronized void mouseMoved( final MouseEvent e )
+		{
+			x = e.getX();
+			y = e.getY();
+			onMouseMoved();
+		}
+
+		public synchronized int getX()
+		{
+			return x;
+		}
+
+		public synchronized int getY()
+		{
+			return y;
+		}
+
+		public synchronized boolean isMouseInsidePanel()
+		{
+			return isInside;
+		}
+
+		@Override
+		public synchronized void mouseEntered( final MouseEvent e )
+		{
+			isInside = true;
+		}
+
+		@Override
+		public synchronized void mouseExited( final MouseEvent e )
+		{
+			isInside = false;
+		}
+
+		@Override
+		public void mouseClicked( final MouseEvent e )
+		{}
+
+		@Override
+		public void mousePressed( final MouseEvent e )
+		{}
+
+		@Override
+		public void mouseReleased( final MouseEvent e )
+		{}
+	}
+
+	@Override
+	public boolean requestFocusInWindow()
+	{
+		return getDisplayComponent().requestFocusInWindow();
+	}
+}

--- a/src/main/java/bdv/viewer/InteractiveDisplay.java
+++ b/src/main/java/bdv/viewer/InteractiveDisplay.java
@@ -1,0 +1,40 @@
+package bdv.viewer;
+
+import java.awt.Component;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelListener;
+import org.scijava.listeners.Listeners;
+
+public interface InteractiveDisplay
+{
+	/**
+	 * OverlayRenderers can be added/removed here.
+	 * {@link OverlayRenderer#drawOverlays} is invoked for each renderer (in the order they were added).
+	 */
+	Listeners< OverlayRenderer > overlays();
+
+	/**
+	 * Add new event handler. Depending on the interfaces implemented by
+	 * <code>handler</code> calls {@link Component#addKeyListener(KeyListener)},
+	 * {@link Component#addMouseListener(MouseListener)},
+	 * {@link Component#addMouseMotionListener(MouseMotionListener)},
+	 * {@link Component#addMouseWheelListener(MouseWheelListener)}.
+	 *
+	 * @param handler handler to remove
+	 */
+	void addHandler( Object handler );
+
+	/**
+	 * Remove an event handler. Add new event handler. Depending on the
+	 * interfaces implemented by <code>handler</code> calls
+	 * {@link Component#removeKeyListener(KeyListener)},
+	 * {@link Component#removeMouseListener(MouseListener)},
+	 * {@link Component#removeMouseMotionListener(MouseMotionListener)},
+	 * {@link Component#removeMouseWheelListener(MouseWheelListener)}.
+	 *
+	 * @param handler handler to remove
+	 */
+	void removeHandler( Object handler );
+}

--- a/src/main/java/bdv/viewer/InteractiveDisplayCanvas.java
+++ b/src/main/java/bdv/viewer/InteractiveDisplayCanvas.java
@@ -54,7 +54,7 @@ import org.scijava.listeners.Listeners;
  *
  * @author Tobias Pietzsch
  */
-public class InteractiveDisplayCanvas extends JComponent
+public class InteractiveDisplayCanvas extends JComponent implements InteractiveDisplay
 {
 	/**
 	 * Mouse/Keyboard handler that manipulates the view transformation.
@@ -64,7 +64,7 @@ public class InteractiveDisplayCanvas extends JComponent
 	/**
 	 * To draw this component, {@link OverlayRenderer#drawOverlays} is invoked for each renderer.
 	 */
-	final private Listeners.List< OverlayRenderer > overlayRenderers;
+	private final Listeners.List< OverlayRenderer > overlayRenderers;
 
 	/**
 	 * Create a new {@code InteractiveDisplayCanvas}.
@@ -112,6 +112,7 @@ public class InteractiveDisplayCanvas extends JComponent
 	 * OverlayRenderers can be added/removed here.
 	 * {@link OverlayRenderer#drawOverlays} is invoked for each renderer (in the order they were added).
 	 */
+	@Override
 	public Listeners< OverlayRenderer > overlays()
 	{
 		return overlayRenderers;
@@ -126,6 +127,7 @@ public class InteractiveDisplayCanvas extends JComponent
 	 *
 	 * @param h handler to remove
 	 */
+	@Override
 	public void addHandler( final Object h )
 	{
 		if ( h instanceof KeyListener )
@@ -154,6 +156,7 @@ public class InteractiveDisplayCanvas extends JComponent
 	 *
 	 * @param h handler to remove
 	 */
+	@Override
 	public void removeHandler( final Object h )
 	{
 		if ( h instanceof KeyListener )

--- a/src/main/java/bdv/viewer/NavigationActions.java
+++ b/src/main/java/bdv/viewer/NavigationActions.java
@@ -28,15 +28,18 @@
  */
 package bdv.viewer;
 
-import bdv.viewer.AbstractViewerPanel.AlignPlane;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+
 import javax.swing.ActionMap;
 import javax.swing.InputMap;
+
 import org.scijava.ui.behaviour.KeyStrokeAdder;
 import org.scijava.ui.behaviour.util.Actions;
 import org.scijava.ui.behaviour.util.InputActionBindings;
+
+import bdv.viewer.AbstractViewerPanel.AlignPlane;
 
 public class NavigationActions extends Actions
 {
@@ -69,9 +72,9 @@ public class NavigationActions extends Actions
 	 * @param actions
 	 *            navigation actions are installed here.
 	 * @param viewer
-	 *            Navigation actions are targeted at this {@link ViewerPanel}.
+	 *            Navigation actions are targeted at this {@link AbstractViewerPanel}.
 	 */
-	public static void install( final Actions actions, final ViewerPanel viewer, final boolean is2D )
+	public static void install( final Actions actions, final AbstractViewerPanel viewer, final boolean is2D )
 	{
 		installModeActions( actions, viewer.state() );
 		installSourceActions( actions, viewer.state() );
@@ -105,7 +108,7 @@ public class NavigationActions extends Actions
 		} );
 	}
 
-	public static void installAlignPlaneActions( final Actions actions, final ViewerPanel viewer, final boolean is2D )
+	public static void installAlignPlaneActions( final Actions actions, final AbstractViewerPanel viewer, final boolean is2D )
 	{
 		actions.runnableAction( () -> viewer.align( AlignPlane.XY ), ALIGN_XY_PLANE, ALIGN_XY_PLANE_KEYS );
 		if ( !is2D )
@@ -116,7 +119,7 @@ public class NavigationActions extends Actions
 	}
 
 	@Deprecated
-	public static void installAlignPlaneAction( final Actions actions, final ViewerPanel viewer, final AlignPlane plane, final String... defaultKeyStrokes )
+	public static void installAlignPlaneAction( final Actions actions, final AbstractViewerPanel viewer, final AlignPlane plane, final String... defaultKeyStrokes )
 	{
 		switch ( plane )
 		{

--- a/src/main/java/bdv/viewer/NavigationActions.java
+++ b/src/main/java/bdv/viewer/NavigationActions.java
@@ -28,7 +28,7 @@
  */
 package bdv.viewer;
 
-import bdv.viewer.ViewerPanel.AlignPlane;
+import bdv.viewer.AbstractViewerPanel.AlignPlane;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;

--- a/src/main/java/bdv/viewer/ViewerFrame.java
+++ b/src/main/java/bdv/viewer/ViewerFrame.java
@@ -28,10 +28,6 @@
  */
 package bdv.viewer;
 
-import bdv.TransformEventHandler;
-import bdv.ui.CardPanel;
-import bdv.ui.BdvDefaultCards;
-import bdv.ui.splitpanel.SplitPanel;
 import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -47,7 +43,11 @@ import org.scijava.ui.behaviour.util.Behaviours;
 import org.scijava.ui.behaviour.util.InputActionBindings;
 import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
+import bdv.TransformEventHandler;
 import bdv.cache.CacheControl;
+import bdv.ui.BdvDefaultCards;
+import bdv.ui.CardPanel;
+import bdv.ui.splitpanel.SplitPanel;
 import bdv.util.AWTUtils;
 
 /**
@@ -130,7 +130,7 @@ public class ViewerFrame extends JFrame
 		final MouseAndKeyHandler mouseAndKeyHandler = new MouseAndKeyHandler();
 		mouseAndKeyHandler.setInputMap( triggerbindings.getConcatenatedInputTriggerMap() );
 		mouseAndKeyHandler.setBehaviourMap( triggerbindings.getConcatenatedBehaviourMap() );
-		mouseAndKeyHandler.setKeypressManager( optional.values.getKeyPressedManager(), viewer.getDisplay() );
+		mouseAndKeyHandler.setKeypressManager( optional.values.getKeyPressedManager(), viewer.getDisplayComponent() );
 		viewer.getDisplay().addHandler( mouseAndKeyHandler );
 
 		// TODO: should be a field?

--- a/src/main/java/bdv/viewer/ViewerPanel.java
+++ b/src/main/java/bdv/viewer/ViewerPanel.java
@@ -103,34 +103,34 @@ public class ViewerPanel extends AbstractViewerPanel implements OverlayRenderer,
 	/**
 	 * Legacy wrapper around {@code state} to support deprecated API
 	 */
-	protected final bdv.viewer.state.ViewerState deprecatedState;
+	private final bdv.viewer.state.ViewerState deprecatedState;
 
 	/**
 	 * Renders the current state for the {@link #display}.
 	 */
-	protected final MultiResolutionRenderer imageRenderer;
+	private final MultiResolutionRenderer imageRenderer;
 
 	/**
 	 * TODO
 	 */
-	protected final BufferedImageOverlayRenderer renderTarget;
+	private final BufferedImageOverlayRenderer renderTarget;
 
 	/**
 	 * Overlay navigation boxes.
 	 */
 	// TODO: move to specialized class
-	protected final MultiBoxOverlayRenderer multiBoxOverlayRenderer;
+	private final MultiBoxOverlayRenderer multiBoxOverlayRenderer;
 
 	/**
 	 * Overlay current source name and current timepoint.
 	 */
 	// TODO: move to specialized class
-	protected final SourceInfoOverlayRenderer sourceInfoOverlayRenderer;
+	private final SourceInfoOverlayRenderer sourceInfoOverlayRenderer;
 
 	/**
 	 * TODO
 	 */
-	protected final ScaleBarOverlayRenderer scaleBarOverlayRenderer;
+	private final ScaleBarOverlayRenderer scaleBarOverlayRenderer;
 
 	private final TransformEventHandler transformEventHandler;
 
@@ -138,9 +138,9 @@ public class ViewerPanel extends AbstractViewerPanel implements OverlayRenderer,
 	 * Canvas used for displaying the rendered {@link #renderTarget image} and
 	 * overlays.
 	 */
-	protected final InteractiveDisplayCanvas display;
+	private final InteractiveDisplayCanvas display;
 
-	protected final JSlider sliderTime;
+	private final JSlider sliderTime;
 
 	private boolean blockSliderTimeEvents;
 
@@ -149,23 +149,23 @@ public class ViewerPanel extends AbstractViewerPanel implements OverlayRenderer,
 	 * {@link ViewerPanel}, that is, {@link #painterThread} and
 	 * {@link #renderingExecutorService}.
 	 */
-	protected ThreadGroup threadGroup;
+	private ThreadGroup threadGroup;
 
 	/**
 	 * Thread that triggers repainting of the display.
 	 */
-	protected final PainterThread painterThread;
+	private final PainterThread painterThread;
 
 	/**
 	 * The {@link ExecutorService} used for rendereing.
 	 */
-	protected final ExecutorService renderingExecutorService;
+	private final ExecutorService renderingExecutorService;
 
 	/**
 	 * Manages visibility and currentness of sources and groups, as well as
 	 * grouping of sources, and display mode.
 	 */
-	protected final VisibilityAndGrouping visibilityAndGrouping;
+	private final VisibilityAndGrouping visibilityAndGrouping;
 
 	/**
 	 * These listeners will be notified about changes to the
@@ -189,21 +189,21 @@ public class ViewerPanel extends AbstractViewerPanel implements OverlayRenderer,
 	 * to make smooth transitions when {@link #align(AlignPlane) aligning to
 	 * orthogonal planes}.
 	 */
-	protected AbstractTransformAnimator currentAnimator = null;
+	private AbstractTransformAnimator currentAnimator = null;
 
 	/**
 	 * A list of currently incomplete (see {@link OverlayAnimator#isComplete()})
 	 * animators. Initially, this contains a {@link TextOverlayAnimator} showing
 	 * the "press F1 for help" message.
 	 */
-	protected final ArrayList< OverlayAnimator > overlayAnimators;
+	private final ArrayList< OverlayAnimator > overlayAnimators;
 
 	/**
 	 * Fade-out overlay of recent messages. See {@link #showMessage(String)}.
 	 */
-	protected final MessageOverlayAnimator msgOverlay;
+	private final MessageOverlayAnimator msgOverlay;
 
-	protected final ViewerOptions.Values options;
+	private final ViewerOptions.Values options;
 
 	public ViewerPanel( final List< SourceAndConverter< ? > > sources, final int numTimePoints, final CacheControl cacheControl )
 	{


### PR DESCRIPTION
* Split out abstract base class from `AbstractViewerPanel` from `ViewerPanel`.
  `AbstractViewerPanel` is used instead of ViewerPanel where possible.
    This will allow to re-use bookmark, bounding box, manual transform tools in BigVolumeViewer.
* Use scijava-listeners for `ViewerPanel` listeners
* Reduce usage of deprecated `bdv.viewer.state.ViewerState`
* make `AbstractViewerPanel.align(...)` public