### PR TITLE
Allow finer control of caches in image loaders

### DIFF
--- a/src/main/java/bdv/cache/CacheOverrider.java
+++ b/src/main/java/bdv/cache/CacheOverrider.java
@@ -1,0 +1,14 @@
+package bdv.cache;
+
+import bdv.img.cache.VolatileGlobalCellCache;
+
+/**
+ * Allows to override the {@link bdv.img.cache.VolatileGlobalCellCache} in
+ * ImageLoader(s) which implement this interface.
+ */
+
+public interface CacheOverrider {
+
+    void setCache(VolatileGlobalCellCache cache);
+
+}

--- a/src/main/java/bdv/img/cache/VolatileGlobalCellCache.java
+++ b/src/main/java/bdv/img/cache/VolatileGlobalCellCache.java
@@ -130,6 +130,21 @@ public class VolatileGlobalCellCache implements CacheControl
 	/**
 	 * Create a new global cache with the specified fetch queue. (It is the
 	 * callers responsibility to create fetcher threads that serve the queue.)
+	 * and the backing cache.
+	 *
+	 * @param queue
+	 *            queue to which asynchronous data loading jobs are submitted
+	 * @param backingCache cache used to stored the cells
+	 */
+	public VolatileGlobalCellCache( final BlockingFetchQueues< Callable< ? > > queue, final LoaderCache< Key, Cell< ? > > backingCache)
+	{
+		this.queue = queue;
+		this.backingCache = backingCache;
+	}
+
+	/**
+	 * Create a new global cache with the specified fetch queue. (It is the
+	 * callers responsibility to create fetcher threads that serve the queue.)
 	 *
 	 * @param queue
 	 *            queue to which asynchronous data loading jobs are submitted

--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -30,6 +30,7 @@ package bdv.img.hdf5;
 
 import bdv.AbstractViewerSetupImgLoader;
 import bdv.ViewerImgLoader;
+import bdv.cache.CacheOverrider;
 import bdv.cache.SharedQueue;
 import bdv.img.cache.VolatileGlobalCellCache;
 import bdv.util.ConstantRandomAccessible;
@@ -76,7 +77,7 @@ import net.imglib2.view.Views;
 import static bdv.img.hdf5.Util.getResolutionsPath;
 import static bdv.img.hdf5.Util.getSubdivisionsPath;
 
-public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
+public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader, CacheOverrider
 {
 	protected File hdf5File;
 
@@ -309,6 +310,20 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 	{
 		open();
 		return cache;
+	}
+
+	@Override
+	public synchronized void setCache(VolatileGlobalCellCache cache) {
+		if ( isOpen )
+		{
+			if ( !isOpen )
+				return;
+			if ( createdSharedQueue != null )
+				createdSharedQueue.shutdown();
+			cache.clearCache();
+			createdSharedQueue = null;
+		}
+		this.cache = cache;
 	}
 
 	public Hdf5VolatileShortArrayLoader getShortArrayLoader()

--- a/src/main/java/bdv/img/imaris/ImarisImageLoader.java
+++ b/src/main/java/bdv/img/imaris/ImarisImageLoader.java
@@ -28,6 +28,7 @@
  */
 package bdv.img.imaris;
 
+import bdv.cache.CacheOverrider;
 import bdv.img.hdf5.Util;
 import bdv.util.MipmapTransforms;
 import ch.systemsx.cisd.hdf5.HDF5DataClass;
@@ -65,7 +66,7 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.volatiles.VolatileUnsignedShortType;
 
-public class ImarisImageLoader< T extends NativeType< T >, V extends Volatile< T > & NativeType< V > , A extends VolatileAccess > implements ViewerImgLoader
+public class ImarisImageLoader< T extends NativeType< T >, V extends Volatile< T > & NativeType< V > , A extends VolatileAccess > implements ViewerImgLoader, CacheOverrider
 {
 	private IHDF5Access hdf5Access;
 
@@ -283,6 +284,17 @@ public class ImarisImageLoader< T extends NativeType< T >, V extends Volatile< T
 	{
 		open();
 		return cache;
+	}
+
+	@Override
+	public synchronized void setCache(VolatileGlobalCellCache cache) {
+		if ( isOpen )
+		{
+			if ( !isOpen )
+				return;
+			cache.clearCache();
+		}
+		this.cache = cache;
 	}
 
 	@Override

--- a/src/main/java/bdv/img/n5/N5ImageLoader.java
+++ b/src/main/java/bdv/img/n5/N5ImageLoader.java
@@ -31,6 +31,7 @@ package bdv.img.n5;
 import bdv.AbstractViewerSetupImgLoader;
 import bdv.ViewerImgLoader;
 import bdv.cache.CacheControl;
+import bdv.cache.CacheOverrider;
 import bdv.cache.SharedQueue;
 import bdv.img.cache.SimpleCacheArrayLoader;
 import bdv.img.cache.VolatileGlobalCellCache;
@@ -100,7 +101,7 @@ import static bdv.img.n5.BdvN5Format.DATA_TYPE_KEY;
 import static bdv.img.n5.BdvN5Format.DOWNSAMPLING_FACTORS_KEY;
 import static bdv.img.n5.BdvN5Format.getPathName;
 
-public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
+public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader, CacheOverrider
 {
 	private final File n5File;
 
@@ -184,6 +185,20 @@ public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
 				isOpen = true;
 			}
 		}
+	}
+
+	@Override
+	public synchronized void setCache(VolatileGlobalCellCache cache) {
+		if ( isOpen )
+		{
+			if ( !isOpen )
+				return;
+			if ( createdSharedQueue != null )
+				createdSharedQueue.shutdown();
+			cache.clearCache();
+			createdSharedQueue = null;
+		}
+		this.cache = cache;
 	}
 
 	/**

--- a/src/main/java/bdv/img/remote/RemoteImageLoader.java
+++ b/src/main/java/bdv/img/remote/RemoteImageLoader.java
@@ -33,6 +33,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.HashMap;
 
+import bdv.cache.CacheOverrider;
 import com.google.gson.GsonBuilder;
 
 import bdv.AbstractViewerSetupImgLoader;
@@ -56,7 +57,7 @@ import net.imglib2.type.volatiles.VolatileUnsignedShortType;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.view.Views;
 
-public class RemoteImageLoader implements ViewerImgLoader
+public class RemoteImageLoader implements ViewerImgLoader, CacheOverrider
 {
 	protected String baseUrl;
 
@@ -137,6 +138,17 @@ public class RemoteImageLoader implements ViewerImgLoader
 	{
 		tryopen();
 		return cache;
+	}
+
+	@Override
+	public synchronized void setCache(VolatileGlobalCellCache cache) {
+		if ( isOpen )
+		{
+			if ( !isOpen )
+				return;
+			cache.clearCache();
+		}
+		this.cache = cache;
 	}
 
 	public MipmapInfo getMipmapInfo( final int setupId )


### PR DESCRIPTION
Adds a CacheOverrider interface and implementations of this interface in:

* Hdf5ImageLoader
* N5ImageLoader
* ImarisImageLoader
* RemoteImageLoader

Adds a constructor in VolatileGlobalCellCache with a LoaderCache argument.

Together these modifications allow to get a finer control over the caching mechanism used when loading a dataset. In practice, using a BoundedSoftRefLoaderCache with a fixed number a cells instead of a SoftRefLoaderCache can lead to very significant performance improvement. Cached cells can be released: 1 - before the RAM gets full, 2 - more efficiently (and aggressively) than when SoftRefs are released by the garbage collector.

This PR maintains backward compatibility and does not modify the default behaviour (SoftRefLoaderCache).