### PR TITLE
adds Closeable interface to image loaders with a close method

### DIFF
--- a/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
+++ b/src/main/java/bdv/img/hdf5/Hdf5ImageLoader.java
@@ -36,6 +36,8 @@ import bdv.util.ConstantRandomAccessible;
 import bdv.util.MipmapTransforms;
 import ch.systemsx.cisd.hdf5.HDF5Factory;
 import ch.systemsx.cisd.hdf5.IHDF5Reader;
+
+import java.io.Closeable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,7 +78,7 @@ import net.imglib2.view.Views;
 import static bdv.img.hdf5.Util.getResolutionsPath;
 import static bdv.img.hdf5.Util.getSubdivisionsPath;
 
-public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
+public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader, Closeable
 {
 	protected File hdf5File;
 
@@ -239,6 +241,7 @@ public class Hdf5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoade
 	 * after {@link #close()} will cause the hdf5 file to be reopened (with a
 	 * new cache).
 	 */
+	@Override
 	public void close()
 	{
 		if ( isOpen )

--- a/src/main/java/bdv/img/n5/N5ImageLoader.java
+++ b/src/main/java/bdv/img/n5/N5ImageLoader.java
@@ -36,6 +36,8 @@ import bdv.img.cache.SimpleCacheArrayLoader;
 import bdv.img.cache.VolatileGlobalCellCache;
 import bdv.util.ConstantRandomAccessible;
 import bdv.util.MipmapTransforms;
+
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -100,7 +102,7 @@ import static bdv.img.n5.BdvN5Format.DATA_TYPE_KEY;
 import static bdv.img.n5.BdvN5Format.DOWNSAMPLING_FACTORS_KEY;
 import static bdv.img.n5.BdvN5Format.getPathName;
 
-public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
+public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader, Closeable
 {
 	private final File n5File;
 
@@ -192,6 +194,7 @@ public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
 	 * after {@link #close()} will cause the n5 to be reopened (with a
 	 * new cache).
 	 */
+	@Override
 	public void close()
 	{
 		if ( isOpen )


### PR DESCRIPTION
This PR simply adds a Closeable interface to Image Loaders which already contained a close() method.

This would allow to replace

```
			if ( imgLoader instanceof N5ImageLoader )
			{
				( ( N5ImageLoader ) imgLoader ).close();
			}
			else if ( imgLoader instanceof N5OMEZarrImageLoader )
			{
				( ( N5OMEZarrImageLoader ) imgLoader ).close();
			}
                       else if ( imgLoader instanceof Hdf5ImageLoader )
			{
				( ( N5OMEZarrImageLoader ) imgLoader ).close();
			}
```

with

```
if ( imgLoader instanceof Closeable) {
	( ( Closeable) imgLoader ).close();
}
```
