### PR TITLE
suppress output in TransformedBoxOverlaySource.repaint

### DIFF
--- a/src/main/java/bdv/tools/boundingbox/TransformedBoxOverlaySource.java
+++ b/src/main/java/bdv/tools/boundingbox/TransformedBoxOverlaySource.java
@@ -134,7 +134,6 @@ public class TransformedBoxOverlaySource
 
 	private void repaint()
 	{
-		System.out.println( "TransformedBoxOverlaySource.repaint" );
 		boxOverlay.fillIntersection( isVisible );
 		if ( isVisible )
 		{


### PR DESCRIPTION
removes a print statement.

I'm using this awesome functionality in n5-viewer now, and ran into this.