### PR TITLE
Initial version of zarr reader based on the mobie-io hackathon code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-algorithm</artifactId>
+			<version>0.13.0</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
@@ -213,11 +214,20 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.embl.mobie</groupId>
-            <artifactId>mobie-io</artifactId>
-            <version>1.2.13-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>bigdataviewer-vistools</artifactId>
+			<version>1.0.0-beta-28</version>
+		</dependency>
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-imglib2</artifactId>
+<!--			<version>4.0.0</version>-->
+		</dependency>
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-zarr</artifactId>
+<!--			<version>0.0.8-SNAPSHOT</version>-->
+		</dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -213,5 +213,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.embl.mobie</groupId>
+            <artifactId>mobie-io</artifactId>
+            <version>1.2.13-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/bdv/img/omezarr/MultiscaleImage.java
+++ b/src/main/java/bdv/img/omezarr/MultiscaleImage.java
@@ -26,12 +26,18 @@ import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
 
-import javax.annotation.Nullable;
+//import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 
 import static bdv.img.omezarr.Multiscales.MULTI_SCALE_KEY;
 
+/**
+ * As n5-zarr already provides dimensions in the java order, this class also stores dimensions in the java order.
+ *
+ * @param <T> Image type.
+ * @param <V> Volatile image type.
+ */
 public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V extends Volatile< T > & NativeType< V > & RealType< V > >
 {
 	private final String multiscalePath;
@@ -40,7 +46,7 @@ public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V exten
 
 	private int numResolutions;
 
-	private long[] dimensions;
+	private long[] dimensions; // Java order of axes
 
 	private T type;
 
@@ -56,7 +62,7 @@ public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V exten
 
 	private DataType dataType;
 
-	private long[][] multiDimensions;
+	private long[][] multiDimensions; // Java order of axes
 
 	private DataType[] multiDataType;
 
@@ -65,7 +71,7 @@ public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V exten
 	 */
 	public MultiscaleImage(
 			final String multiscalePath,
-			@Nullable final SharedQueue queue )
+			final SharedQueue queue )
 	{
 		this.multiscalePath = multiscalePath;
 		this.queue = queue;
@@ -123,6 +129,7 @@ public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V exten
 
 			for (int resolution = numResolutions-1; resolution >= 0; --resolution) {
 				final DatasetAttributes attributes = n5ZarrReader.getDatasetAttributes(datasets[resolution].path);
+				// n5-zarr provides dimensions in the java order
 				multiDimensions[resolution] = attributes.getDimensions();
 				multiDataType[resolution] = attributes.getDataType();
 			}
@@ -258,19 +265,8 @@ public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V exten
 
 	public static void main( String[] args )
 	{
-		//final String multiscalePath = "/data1/gabor.kovacs/davidf_sample_dataset/SmartSPIM_617052_sample.zarr";
-//		final String multiscalePath = "/home/gabor.kovacs/data/davidf_sample_dataset/SmartSPIM_617052_sample.zarr";
 		final String multiscalePath = "/Users/kgabor/data/davidf_sample_dataset/SmartSPIM_617052_sample.zarr";
 		final MultiscaleImage< ?, ? > multiscaleImage = new MultiscaleImage<>( multiscalePath, null );
 		multiscaleImage.dimensions();
-
-		// Show as imagePlus
-//		final ImageJ imageJ = new ImageJ();
-//		imageJ.ui().showUI();
-//		final DefaultPyramidal5DImageData< ?, ? > dataset = new DefaultPyramidal5DImageData<>( imageJ.context(), "image", multiscaleImage );
-//		imageJ.ui().show( dataset.asPyramidalDataset() );
-//
-//		// Also show the displayed image in BDV
-//		imageJ.command().run( OpenInBDVCommand.class, true );
 	}
 }

--- a/src/main/java/bdv/img/omezarr/MultiscaleImage.java
+++ b/src/main/java/bdv/img/omezarr/MultiscaleImage.java
@@ -1,0 +1,276 @@
+package bdv.img.omezarr;
+
+import bdv.img.cache.VolatileCachedCellImg;
+import bdv.util.volatiles.SharedQueue;
+import bdv.util.volatiles.VolatileTypeMatcher;
+import bdv.util.volatiles.VolatileViews;
+import com.google.gson.JsonArray;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Volatile;
+import net.imglib2.cache.img.CachedCellImg;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Cast;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+
+import static bdv.img.omezarr.Multiscales.MULTI_SCALE_KEY;
+
+public class MultiscaleImage< T extends NativeType< T > & RealType< T >, V extends Volatile< T > & NativeType< V > & RealType< V > >
+{
+	private final String multiscalePath;
+
+	private final SharedQueue queue;
+
+	private int numResolutions;
+
+	private long[] dimensions;
+
+	private T type;
+
+	private V volatileType;
+
+	private CachedCellImg< T, ? >[] imgs;
+
+	private RandomAccessibleInterval< V >[] vimgs;
+
+	private Multiscales multiscales;
+
+	private int multiscaleArrayIndex = 0; // TODO (see comments within code)
+
+	private DataType dataType;
+
+	private long[][] multiDimensions;
+
+	private DataType[] multiDataType;
+
+	/**
+	 * TODO
+	 */
+	public MultiscaleImage(
+			final String multiscalePath,
+			@Nullable final SharedQueue queue )
+	{
+		this.multiscalePath = multiscalePath;
+		this.queue = queue;
+	}
+
+	private void init()
+	{
+		if ( imgs != null ) return;
+
+		try
+		{
+			// FIXME support S3
+			final N5ZarrReader n5ZarrReader = new N5ZarrReader( multiscalePath );
+
+			// Fetch metadata
+			//
+			Multiscales[] multiscalesArray = n5ZarrReader.getAttribute( "", MULTI_SCALE_KEY, Multiscales[].class );
+
+			// In principle the call above would be sufficient.
+			// However since we need to support different
+			// versions of OME-Zarrr we need to "manually"
+			// fix some fields.
+			// Thus, we parse the same JSON again and fill in missing
+			// information.
+			// TODO: could we do this by means of a JsonDeserializer?
+
+			final JsonArray multiscalesJsonArray = n5ZarrReader.getAttributes( "" ).get( MULTI_SCALE_KEY ).getAsJsonArray();
+			for ( int i = 0; i < multiscalesArray.length; i++ )
+			{
+				multiscalesArray[ i ].applyVersionFixes( multiscalesJsonArray.get( i ).getAsJsonObject() );
+				multiscalesArray[ i ].init();
+			}
+
+			// TODO
+			//   From the spec:
+			//   "If only one multiscale is provided, use it.
+			//   Otherwise, the user can choose by name,
+			//   using the first multiscale as a fallback"
+			//   Right now, we always only use the first one.
+			//   One option would be to add the {@code multiscaleArrayIndex}
+			//   array index as a parameter to the constructor
+			multiscales = multiscalesArray[ multiscaleArrayIndex ];
+
+			// Here, datasets are single resolution N-D Images.
+			// Each dataset represents one resolution layer.
+			final Multiscales.Dataset[] datasets = multiscales.getDatasets();
+			numResolutions = datasets.length;
+
+			// Set the dimensions and data type
+			// from the highest resolution dataset's
+			// metadata.
+
+			multiDimensions = new long[numResolutions][];
+			multiDataType = new DataType[numResolutions];
+
+			for (int resolution = numResolutions-1; resolution >= 0; --resolution) {
+				final DatasetAttributes attributes = n5ZarrReader.getDatasetAttributes(datasets[resolution].path);
+				multiDimensions[resolution] = attributes.getDimensions();
+				multiDataType[resolution] = attributes.getDataType();
+			}
+			dimensions = multiDimensions[0];
+			dataType = multiDataType[0];
+			initTypes( dataType );
+
+			// Initialize the images for all resolutions.
+			//
+			// TODO only on demand
+			imgs = new CachedCellImg[ numResolutions ];
+			vimgs = new RandomAccessibleInterval[ numResolutions ];
+
+			for ( int resolution = 0; resolution < numResolutions; ++resolution )
+			{
+				imgs[ resolution ] = N5Utils.openVolatile( n5ZarrReader, datasets[ resolution ].path );
+
+				if ( queue == null )
+					vimgs[ resolution ] = VolatileViews.wrapAsVolatile( imgs[ resolution ] );
+				else
+					vimgs[ resolution ] = VolatileViews.wrapAsVolatile( imgs[ resolution ], queue );
+			}
+		}
+		catch ( Exception e )
+		{
+			e.printStackTrace();
+			throw new RuntimeException( e );
+		}
+	}
+
+	private void initTypes( DataType dataType )
+	{
+		if ( type != null ) return;
+
+		// TODO JOHN: Does the below code already exists
+		//   somewhere in N5?
+		switch ( dataType ) {
+			case UINT8:
+				type = Cast.unchecked( new UnsignedByteType() );
+				break;
+			case UINT16:
+				type = Cast.unchecked( new UnsignedShortType() );
+				break;
+			case UINT32:
+				type = Cast.unchecked( new UnsignedIntType() );
+				break;
+			case UINT64:
+				type = Cast.unchecked( new UnsignedLongType() );
+				break;
+			case INT8:
+				type = Cast.unchecked( new ByteType() );
+				break;
+			case INT16:
+				type = Cast.unchecked( new ShortType() );
+				break;
+			case INT32:
+				type = Cast.unchecked( new IntType() );
+				break;
+			case INT64:
+				type = Cast.unchecked( new LongType() );
+				break;
+			case FLOAT32:
+				type = Cast.unchecked( new FloatType() );
+				break;
+			case FLOAT64:
+				type = Cast.unchecked( new DoubleType() );
+				break;
+		}
+
+		volatileType = ( V ) VolatileTypeMatcher.getVolatileTypeForType( type );
+	}
+
+	public Multiscales getMultiscales()
+	{
+		return multiscales;
+	}
+
+	public long[] dimensions()
+	{
+		init();
+		return dimensions;
+	}
+
+	public int numResolutions()
+	{
+		init();
+		return numResolutions;
+	}
+
+	public CachedCellImg< T, ? > getImg( final int resolutionLevel )
+	{
+		init();
+		return imgs[ resolutionLevel ];
+	}
+
+	public long[] getDimensions(final int level)
+	{
+		return multiDimensions[level];
+	}
+
+	public RandomAccessibleInterval< V > getVolatileImg( final int resolutionLevel )
+	{
+		init();
+		return vimgs[ resolutionLevel ];
+	}
+
+	public DataType getDataType()
+	{
+		return dataType;
+	}
+
+	public T getType()
+	{
+		init();
+		return type;
+	}
+
+	public V getVolatileType()
+	{
+		init();
+		return volatileType;
+	}
+
+	public SharedQueue getSharedQueue()
+	{
+		return queue;
+	}
+
+	public int numDimensions()
+	{
+		return dimensions.length;
+	}
+
+	public static void main( String[] args )
+	{
+		//final String multiscalePath = "/data1/gabor.kovacs/davidf_sample_dataset/SmartSPIM_617052_sample.zarr";
+//		final String multiscalePath = "/home/gabor.kovacs/data/davidf_sample_dataset/SmartSPIM_617052_sample.zarr";
+		final String multiscalePath = "/Users/kgabor/data/davidf_sample_dataset/SmartSPIM_617052_sample.zarr";
+		final MultiscaleImage< ?, ? > multiscaleImage = new MultiscaleImage<>( multiscalePath, null );
+		multiscaleImage.dimensions();
+
+		// Show as imagePlus
+//		final ImageJ imageJ = new ImageJ();
+//		imageJ.ui().showUI();
+//		final DefaultPyramidal5DImageData< ?, ? > dataset = new DefaultPyramidal5DImageData<>( imageJ.context(), "image", multiscaleImage );
+//		imageJ.ui().show( dataset.asPyramidalDataset() );
+//
+//		// Also show the displayed image in BDV
+//		imageJ.command().run( OpenInBDVCommand.class, true );
+	}
+}

--- a/src/main/java/bdv/img/omezarr/Multiscales.java
+++ b/src/main/java/bdv/img/omezarr/Multiscales.java
@@ -1,0 +1,140 @@
+package bdv.img.omezarr;
+
+import com.google.common.collect.Lists;
+import com.google.gson.JsonElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Copy from {@code org.embl.mobie.io.ome.zarr.util.OmeZarrMultiscales}
+ *
+ */
+public class Multiscales
+{
+    // key in json for multiscales
+    public static final String MULTI_SCALE_KEY = "multiscales";
+
+    // Serialisation
+    private String version;
+    private String name;
+    private String type;
+    private Axis[] axes; // from v0.4+ within JSON
+    private Dataset[] datasets;
+    private CoordinateTransformations[] coordinateTransformations; // from v0.4+ within JSON
+
+    // Runtime
+
+    // Simply contains the {@codeAxes[] axes}
+    // but in reversed order to accommodate
+    // the Java array ordering of the image data.
+    private List< Axis > axisList;
+    private int numDimensions;
+
+    public Multiscales() {
+    }
+
+    public static class Dataset {
+        public String path;
+        public CoordinateTransformations[] coordinateTransformations;
+    }
+
+    public static class CoordinateTransformations {
+        public String type;
+        public double[] scale;
+        public double[] translation;
+        public String path;
+    }
+
+    public static class Axis
+    {
+        public static final String CHANNEL_TYPE = "channel";
+        public static final String TIME_TYPE = "time";
+        public static final String SPATIAL_TYPE = "space";
+
+        public static final String X_AXIS_NAME = "x";
+        public static final String Y_AXIS_NAME = "y";
+        public static final String Z_AXIS_NAME = "z";
+
+        public String name;
+        public String type;
+        public String unit;
+    }
+
+    public void init()
+    {
+        axisList = Lists.reverse( Arrays.asList( axes ) );
+        numDimensions = axisList.size();
+    }
+
+    // TODO Can this be done with a JSONAdapter ?
+    public void applyVersionFixes( JsonElement multiscales )
+    {
+        String version = multiscales.getAsJsonObject().get("version").getAsString();
+        if ( version.equals("0.3") ) {
+            JsonElement axes = multiscales.getAsJsonObject().get("axes");
+            // FIXME
+            //   - populate Axes[]
+            //   - populate coordinateTransformations[]
+            throw new RuntimeException("Parsing version 0.3 not yet implemented.");
+        } else if ( version.equals("0.4") ) {
+            // This should just work automatically
+        } else {
+            JsonElement axes = multiscales.getAsJsonObject().get("axes");
+            // FIXME
+            //   - populate Axes[]
+            //   - populate coordinateTransformations[]
+            throw new RuntimeException("Parsing version "+ version + " is not yet implemented.");
+        }
+    }
+
+    public int getChannelAxisIndex()
+    {
+        for ( int d = 0; d < numDimensions; d++ )
+            if ( axisList.get( d ).type.equals( Axis.CHANNEL_TYPE ) )
+                return d;
+        return -1;
+    }
+
+    public int getTimePointAxisIndex()
+    {
+        for ( int d = 0; d < numDimensions; d++ )
+            if ( axisList.get( d ).type.equals( Axis.TIME_TYPE ) )
+                return d;
+        return -1;
+    }
+
+    public int getSpatialAxisIndex( String axisName )
+    {
+        for ( int d = 0; d < numDimensions; d++ )
+            if ( axisList.get( d ).type.equals( Axis.SPATIAL_TYPE )
+                 && axisList.get( d ).name.equals( axisName ) )
+                return d;
+        return -1;
+    }
+
+    public List< Axis > getAxes()
+    {
+        return axisList;
+    }
+
+    /**
+     * Get the global coordinate transformations.
+     *
+     * @return CoordinateTransformations[]
+     */
+    public CoordinateTransformations[] getCoordinateTransformations()
+    {
+        return coordinateTransformations;
+    }
+
+    public Dataset[] getDatasets()
+    {
+        return datasets;
+    }
+
+    public int numDimensions()
+    {
+        return numDimensions;
+    }
+}

--- a/src/main/java/bdv/img/omezarr/XmlIoZarrImageLoader.java
+++ b/src/main/java/bdv/img/omezarr/XmlIoZarrImageLoader.java
@@ -1,0 +1,75 @@
+package bdv.img.omezarr;
+
+
+import bdv.BigDataViewer;
+import bdv.ViewerImgLoader;
+import bdv.ViewerSetupImgLoader;
+import bdv.export.ProgressWriterConsole;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import bdv.viewer.ViewerOptions;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
+import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
+import mpicbg.spim.data.generic.sequence.XmlIoBasicImgLoader;
+import mpicbg.spim.data.sequence.ViewId;
+import org.jdom2.Element;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import bdv.img.omezarr.ZarrImageLoader;
+import static mpicbg.spim.data.XmlHelpers.loadPath;
+import static mpicbg.spim.data.XmlKeys.IMGLOADER_FORMAT_ATTRIBUTE_NAME;
+
+@ImgLoaderIo( format = "bdv.multimg.zarr", type = ZarrImageLoader.class )
+public class XmlIoZarrImageLoader implements XmlIoBasicImgLoader<ZarrImageLoader>
+{
+    @Override
+    public Element toXml(final ZarrImageLoader imgLoader, final File basePath )
+    {
+        final Element elem = new Element( "ImageLoader" );
+        elem.setAttribute( IMGLOADER_FORMAT_ATTRIBUTE_NAME, "bdv.multimg.zarr" );
+        elem.setAttribute( "version", "1.0" );
+        // TODO (?)
+//			elem.addContent( XmlHelpers.pathElement( "n5", imgLoader.getN5File(), basePath ) );
+        return elem;
+    }
+
+    @Override
+    public ZarrImageLoader fromXml(final Element elem, final File basePath, final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
+    {
+//            final String version = elem.getAttributeValue( "version" );
+        final File zpath = loadPath( elem, "zarr", basePath );
+        final Element zgroupsElem = elem.getChild( "zgroups" );
+        final TreeMap<ViewId, String > zgroups = new TreeMap<>();
+        // TODO validate that sequenceDescription and zgroups have the same entries
+        for ( final Element c : zgroupsElem.getChildren( "zgroup" ) )
+        {
+            final int timepointId = Integer.parseInt( c.getAttributeValue( "timepoint" ) );
+            final int setupId = Integer.parseInt( c.getAttributeValue( "setup" ) );
+            final String path = c.getChild( "path" ).getText();
+            zgroups.put( new ViewId( timepointId,setupId ), path );
+        }
+
+        return new ZarrImageLoader(zpath.getAbsolutePath(), zgroups, sequenceDescription);
+    }
+
+    public static void main( String[] args ) throws SpimDataException
+    {
+        final String fn = "/home/gkovacs/data/davidf_zarr_dataset.xml";
+//        final String fn = "/home/gabor.kovacs/data/davidf_zarr_dataset.xml";
+//        final String fn = "/Users/kgabor/data/davidf_zarr_dataset.xml";
+        final SpimDataMinimal spimData = new XmlIoSpimDataMinimal().load( fn );
+        final ViewerImgLoader imgLoader = ( ViewerImgLoader ) spimData.getSequenceDescription().getImgLoader();
+        final ViewerSetupImgLoader<?, ?> setupImgLoader = imgLoader.getSetupImgLoader(0);
+        setupImgLoader.getMipmapResolutions();
+        BigDataViewer.open(spimData, "BigDataViewer Zarr Example", new ProgressWriterConsole(), ViewerOptions.options());
+        System.out.println( "imgLoader = " + imgLoader );
+        System.out.println( "setupimgLoader = " + setupImgLoader );
+    }
+}
+
+

--- a/src/main/java/bdv/img/omezarr/ZarrImageLoader.java
+++ b/src/main/java/bdv/img/omezarr/ZarrImageLoader.java
@@ -1,0 +1,337 @@
+package bdv.img.omezarr;
+
+
+import bdv.AbstractViewerSetupImgLoader;
+import bdv.ViewerImgLoader;
+import bdv.cache.CacheControl;
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.generic.sequence.ImgLoaderHint;
+import mpicbg.spim.data.sequence.MultiResolutionImgLoader;
+import mpicbg.spim.data.sequence.MultiResolutionSetupImgLoader;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Volatile;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+import org.embl.mobie.io.ome.zarr.hackathon.MultiscaleImage;
+import org.embl.mobie.io.ome.zarr.hackathon.Multiscales;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class ZarrImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
+{
+    private final String zpath;
+    private final Map<ViewId, String> zgroups;
+    private final AbstractSequenceDescription<?, ?, ?> seq;
+
+    private Map<Integer, SetupImgLoader> setupImgLoaders ;
+
+    public ZarrImageLoader(final String zpath, final Map< ViewId, String > zgroups, final AbstractSequenceDescription<?, ?, ?> sequenceDescription)
+    {
+        this.zpath = zpath;
+        this.zgroups = zgroups;
+        this.seq = sequenceDescription;
+    }
+
+    synchronized void openZarr()
+    {
+        if ( setupImgLoaders == null )
+        {
+            try
+            {
+                setupImgLoaders = new HashMap<>();
+                final List<? extends BasicViewSetup> setups = seq.getViewSetupsOrdered();
+                for (final BasicViewSetup setup: setups)
+                {
+                    final SetupImgLoader newLoader = createSetupImgLoader(setup.getId());
+                    setupImgLoaders.put(setup.getId(), newLoader);
+                }
+            }
+            catch ( IOException e )
+            {
+                throw new RuntimeException( e );
+            }
+
+        }
+    }
+
+    private < T extends NativeType< T > & RealType<T>, V extends Volatile< T > & NativeType< V > & RealType<V>>
+    SetupImgLoader< T, V > createSetupImgLoader(final int setupId ) throws IOException {
+        final NavigableSet<Integer> tpIds = new TreeSet<>();
+        for (final ViewId view : zgroups.keySet()) {
+            if (view.getViewSetupId() == setupId) {
+                tpIds.add(view.getTimePointId());
+            }
+        }
+        ViewId firstVId = new ViewId(tpIds.pollFirst(),setupId);
+        if (firstVId == null)
+            return null;
+
+        final MultiscaleImage<T, V> mscImg = new MultiscaleImage<>(Paths.get(zpath,zgroups.get(firstVId)).toString()
+                , null);
+        return new SetupImgLoader<T, V>(mscImg, firstVId, tpIds);
+    }
+
+    @Override
+    public CacheControl getCacheControl()
+    {
+        // FIXME Implement cache control
+        return new CacheControl.Dummy();
+    }
+
+    class SetupImgLoader< T extends NativeType< T > & RealType<T>, V extends Volatile< T > & NativeType< V > & RealType<V> >
+            extends AbstractViewerSetupImgLoader< T, V >
+            implements MultiResolutionSetupImgLoader< T >
+    {
+        private int setupId;
+
+        private NavigableMap<Integer,MultiscaleImage<T,V>> tpMmultiscaleImages = new TreeMap<>();
+        private double[][] mipmapresolutions;
+        private AffineTransform3D[] mipmaptransforms;
+
+        /**
+         * @param firstMscImg First MultiscaleImage instance belonging to this setupId. The only one if 1 timepoint only.
+         *                    We use the MultiscaleImage to determine our own type which we need right at the point of construction.
+         *
+         * @param firstVId First ViewId. Give the setupId for this SetupImgLoader and the timeppointId for the MultiscaleImage.
+         * @param tpIdSet A sorted set of remaining timepoints to be added to this loader.
+         *                NO check at the moment that these images are compatible in type!
+         */
+        public SetupImgLoader(final MultiscaleImage<T,V> firstMscImg, final ViewId firstVId, final SortedSet<Integer> tpIdSet)
+        {
+            super(firstMscImg.getType(), firstMscImg.getVolatileType());
+            setupId = firstVId.getViewSetupId();
+            /* TODO in zarr nothing guarantees that multiple resolutions of an image are of the same type.
+                Must be verified. MultiscaleImage does not support different types of resolutions either.
+             */
+            tpMmultiscaleImages.put(firstVId.getTimePointId(), firstMscImg);
+            for (int tpId: tpIdSet)
+            {
+                // TODO validate that further timepoints have the same type
+                tpMmultiscaleImages.put(tpId,new MultiscaleImage<>(
+                        Paths.get(zpath,zgroups.get(new ViewId(tpId,setupId))).toString(),
+                        null));
+            }
+
+            calculateMipmapTransforms();
+        }
+
+        public SetupImgLoader(final T type, final V volatileType, final int setupId )
+        {
+            super( type, volatileType );
+            this.setupId = setupId;
+        }
+
+        @Override
+        public RandomAccessibleInterval< V > getVolatileImage(final int timepointId, final int level, final ImgLoaderHint... hints )
+        {
+            final MultiscaleImage<T, V> mscImg = tpMmultiscaleImages.get(timepointId);
+            RandomAccessibleInterval<V> volatileImg = mscImg.getVolatileImg(level);
+            return Views.hyperSlice(Views.hyperSlice(volatileImg, 4,0),3,0);
+        }
+
+        @Override
+        public Dimensions getImageSize(final int timepointId, final int level )
+        {
+            return new FinalDimensions(tpMmultiscaleImages.get(timepointId).getDimensions(level));
+        }
+
+        @Override
+        public RandomAccessibleInterval< T > getImage( final int timepointId, final int level, final ImgLoaderHint... hints )
+        {
+            final MultiscaleImage<T, V> mscImg = tpMmultiscaleImages.get(timepointId);
+            return mscImg.getImg(level);
+        }
+
+        /**
+         * Reorder Zarr spatial transformation scaling or translation json vector values into X,Y,Z order.
+         *
+         * Assume that the input vector is in the OME json order, i.e. usually t, ch, z, y, x while
+         * Multiscales.getSpatialAxisIndex already swaps indices to the java order of x, y, z, ch, t.
+         *
+         * @param mscales Multiscales instance that contains the axes order
+         * @param v       Transformation scaling in the order as defined in the OME-Zarr coordinateTransform entry
+         * @param c       Default vector value if not all X, Y, Z axes are present. Usually 1 for scaling, 0 for translation vectors.
+         * @return double[3]: scale values in X, Y, Z order. If an axis is not defined in zarr metadata c is returned.
+         */
+        private double[] getXYZjsonVector(final Multiscales mscales, final double[] v, double c)
+        {
+            final double[] a = {c, c, c};
+            final int d = mscales.numDimensions() - 1;
+            final int xAxisIndex = mscales.getSpatialAxisIndex(Multiscales.Axis.X_AXIS_NAME);
+            if ( xAxisIndex >=0 )
+                a[0] = v[d - xAxisIndex];
+            final int yAxisIndex = mscales.getSpatialAxisIndex(Multiscales.Axis.Y_AXIS_NAME);
+            if ( yAxisIndex >=0 )
+                a[1] = v[d - yAxisIndex];
+            final int zAxisIndex = mscales.getSpatialAxisIndex(Multiscales.Axis.Z_AXIS_NAME);
+            if ( zAxisIndex >=0 )
+                a[2] = v[d - zAxisIndex];
+            return a;
+        }
+
+        /**
+         * Convert a coordinateTransformations JSON entry into an AffineTransform3D instance
+         *
+         * @param mscales Multiscales instance to determine axis indices
+         * @param t Transformation as loaded from the OME JSON by GSON
+         * @return New AffineTransform3D
+         */
+        private AffineTransform3D convertOmeTransform(final Multiscales mscales, final Multiscales.CoordinateTransformations t)
+        {
+            final AffineTransform3D affT = new AffineTransform3D();
+            switch (t.type)
+            {
+                case "scale":
+                    final double[] xyzScale = getXYZjsonVector(mscales, t.scale, 1.);
+                    affT.scale(xyzScale[0], xyzScale[1], xyzScale[2]);
+                    break;
+                case "translation":
+                    affT.setTranslation(getXYZjsonVector(mscales, t.translation, 0.));
+                    break;
+                case "identity":
+                    break;
+                default:
+                    throw new RuntimeException("Unknown transformation type");
+            }
+            return affT;
+        }
+
+        /** Concatenates the given OME transformations into one affine transformation.
+         *
+         * dataset: (t1, t2), multiscales: (t3), then these should be applied in this order.
+         *
+         * As AffineTransform3D, we need to calculate t3 x t2 x t1
+         *
+         * @param mscales Multiscales instance to determine axis order.
+         * @param arrTransforms Array of arrays of OME coordinateTransformations.
+         * @return Concatenated transformations. Return identity if inputs are empty.
+         */
+        private AffineTransform3D concatenateOMETransforms(final Multiscales mscales,
+                                                           final Multiscales.CoordinateTransformations[]... arrTransforms)
+        {
+            final AffineTransform3D affT = new AffineTransform3D();
+            for (int i=arrTransforms.length; i-- >0; ) {
+                if (arrTransforms[i] != null)
+                    for (int j = arrTransforms[i].length; j-- > 0; )
+                        affT.concatenate(convertOmeTransform(mscales, arrTransforms[i][j]));
+            }
+            return affT;
+        }
+
+        /**
+         * Create the 3D affine transformations and calculate the resolution factors
+         * for the multi resolution display relative to the first resolution.
+         *
+         * The 0th dataset must be the finest resolution that will have an identity transformation.
+         *
+         * Convert the OME json transformations into AffineTransform3D objects then normalize them relative
+         * to the 0th dataset. (The json transformations convert into physical coordinates.) Handle both scaling and
+         * translation. Handle both "multiscale" (global transformations for all datasets)
+         * and "dataset" level entries in the OME metadata.
+         *
+         * Assume that the coordinateTransforms do not correct for the pixel center alignment
+         * offsets at the different resolutions levels. Add correction for the pixel center translation here.
+         *
+         * Assume that dimensions and resolutions are defined exactly the same in case there are multiple timepoints.
+         * Definitions are taken from first timepoint.
+         *
+         * Set "mipmaptransforms" and "mipmapresolutions".
+         *
+         */
+        private void calculateMipmapTransforms()
+        {
+            // Assume everything is the same in case there are multiple timepoints
+            final Multiscales mscale = tpMmultiscaleImages.get(0).getMultiscales();
+            final int numResolutions = tpMmultiscaleImages.get(0).numResolutions();
+            final int numDimensions = tpMmultiscaleImages.get(0).numDimensions();
+            final Multiscales.CoordinateTransformations[] globalTransformations = mscale.getCoordinateTransformations();
+
+            mipmaptransforms = new AffineTransform3D[numResolutions];
+            for (int i_res=0; i_res<numResolutions; ++i_res)
+            {
+                final Multiscales.CoordinateTransformations[] datasetTransformations =
+                        mscale.getDatasets()[i_res].coordinateTransformations;
+                mipmaptransforms[i_res] = concatenateOMETransforms(mscale, globalTransformations,
+                        datasetTransformations);
+            }
+
+            // Normalize to the first transformation
+            final AffineTransform3D T0inv = mipmaptransforms[0].inverse();
+            mipmaptransforms[0] = new AffineTransform3D();  // identity
+            for (int j=1; j<numResolutions; ++j)
+            {
+                final AffineTransform3D affT = T0inv.copy();
+                affT.concatenate(mipmaptransforms[j]);
+                mipmaptransforms[j] = affT;
+            }
+
+            // Copy out the scaling from the transformations to the mipmapresolutions
+            mipmapresolutions = new double[numResolutions][];
+            for (int j=0; j<numResolutions; ++j)
+            {
+                mipmapresolutions[j] = new double[] { mipmaptransforms[j].get(0,0),
+                        mipmaptransforms[j].get(1,1),
+                        mipmaptransforms[j].get(2,2) };
+            }
+
+            // Add pixel center correction
+            for (int j=1; j<numResolutions; ++j)
+            {
+                mipmaptransforms[j].translate(
+                        0.5*(mipmapresolutions[j][0]-1.),
+                        0.5*(mipmapresolutions[j][1]-1.),
+                        0.5*(mipmapresolutions[j][2]-1.));
+            }
+
+        }
+
+        @Override
+        public double[][] getMipmapResolutions()
+        {
+            return mipmapresolutions;
+        }
+
+
+        @Override
+        public AffineTransform3D[] getMipmapTransforms()
+        {
+            return mipmaptransforms;
+        }
+
+        @Override
+        public int numMipmapLevels()
+        {
+            return tpMmultiscaleImages.get(0).numResolutions();
+        }
+
+        @Override
+        public VoxelDimensions getVoxelSize(final int timepointId )
+        {
+            return null;
+        }
+    }
+
+    @Override
+    public SetupImgLoader getSetupImgLoader( final int setupId )
+    {
+        openZarr();
+        return setupImgLoaders.get(setupId);
+    }
+
+    // TODO ?
+//		@Override
+//		public void setNumFetcherThreads( final int n ) {}
+
+    // TODO ?
+//		@Override
+//		public void setCreatedSharedQueue( final SharedQueue createdSharedQueue ) {}
+}

--- a/src/main/java/bdv/img/omezarr/ZarrImageLoader.java
+++ b/src/main/java/bdv/img/omezarr/ZarrImageLoader.java
@@ -19,8 +19,8 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
-import org.embl.mobie.io.ome.zarr.hackathon.MultiscaleImage;
-import org.embl.mobie.io.ome.zarr.hackathon.Multiscales;
+import bdv.img.omezarr.MultiscaleImage;
+import bdv.img.omezarr.Multiscales;
 
 import java.io.IOException;
 import java.nio.file.Paths;


### PR DESCRIPTION
The mobie-io hackathon code for metadata processing is now copied into bigdataviewer-core directly. This is temporary, this code will be moved into the new OME-NGFF repository. This implementation supports 5 dimensional ome-zarr images only and have further assumptions that defined views are compatible with each other.