### PR TITLE
Add bigdataviewer-omezarr dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
 			<artifactId>imglib2</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.bigdataviewer</groupId>
+			<artifactId>bigdataviewer-omezarr</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-realtransform</artifactId>
 		</dependency>


### PR DESCRIPTION
Currently the new `bigdataviewer-omezarr` package is not part of `pom-scijava` so we need an explicit version number in the dependency.