### PR TITLE
Add AbstractSpimSource::reload method

### DIFF
--- a/src/main/java/bdv/AbstractSpimSource.java
+++ b/src/main/java/bdv/AbstractSpimSource.java
@@ -277,4 +277,18 @@ public abstract class AbstractSpimSource< T extends NumericType< T > > implement
 	{
 		return setupId;
 	}
+
+	/**
+	 * Invalidate cached source transformations, triggering a reload from {@code SpimData}.
+	 * <p>
+	 * Implementation Note:
+	 * This method was added so that BigStitcher can trigger reloading source
+	 * transforms from ViewRegistrations. It doesn't currently trigger update of
+	 * anything else (MissingViews, available timepoints, etc.) However, if the
+	 * need for these arises, this method would be a good place to put it.
+	 */
+	public void reload()
+	{
+		currentTimePointIndex = -1;
+	}
 }


### PR DESCRIPTION
This is for BigStitcher to easily update transforms in `SpimData`. `AbstractSpimSource` caches transformations for all resolution levels of the current time-point. Unless the time-point changes, these transformations are not updated if `ViewRegistrations` in `SpimData` are changed. The new `AbstractSpimSource::reload` allows to trigger a reload.