### PR TITLE
Change the N5Properties api

### DIFF
--- a/src/main/java/bdv/img/n5/DefaultN5Properties.java
+++ b/src/main/java/bdv/img/n5/DefaultN5Properties.java
@@ -34,7 +34,7 @@ import org.janelia.saalfeldlab.n5.N5Reader;
 public class DefaultN5Properties implements N5Properties
 {
 	@Override
-	public String getDatasetPath( final int setupId, final int timepointId, final int level )
+	public String getDatasetPath( final N5Reader n5, final int setupId, final int timepointId, final int level )
 	{
 		return BdvN5Format.getPathName( setupId, timepointId, level );
 	}
@@ -56,7 +56,7 @@ public class DefaultN5Properties implements N5Properties
 	@Override
 	public long[] getDimensions( final N5Reader n5, final int setupId, final int timepointId, final int level  )
 	{
-		final String path = getDatasetPath( setupId, timepointId, level );
+		final String path = getDatasetPath( n5, setupId, timepointId, level );
 		return n5.getDatasetAttributes( path ).getDimensions();
 	}
 }

--- a/src/main/java/bdv/img/n5/N5ImageLoader.java
+++ b/src/main/java/bdv/img/n5/N5ImageLoader.java
@@ -210,7 +210,7 @@ public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
 						final int setup = viewId.getViewSetupId();
 						final int tp = viewId.getTimePointId();
 						final int numLevels = setupIdToNumLevels.get( setup );
-						IntStream.range( 0, numLevels ).parallel().forEach( level -> n5.getDatasetAttributes( n5properties.getDatasetPath( setup, tp, level ) ) );
+						IntStream.range( 0, numLevels ).parallel().forEach( level -> n5.getDatasetAttributes( n5properties.getDatasetPath( n5, setup, tp, level ) ) );
 					} );
 				} ).join();
 //				System.out.println( "Pre-fetched dataset attributes." );
@@ -379,7 +379,7 @@ public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
 		{
 			final int priority = numMipmapLevels() - 1 - level;
 			final CacheHints cacheHints = new CacheHints( loadingStrategy, priority, false );
-			final String datasetPath = n5properties.getDatasetPath( setupId, timepointId, level );
+			final String datasetPath = n5properties.getDatasetPath( n5, setupId, timepointId, level );
 			return N5ImageLoader.this.prepareCachedImage( datasetPath, setupId, timepointId, level, cacheHints, type );
 		}
 

--- a/src/main/java/bdv/img/n5/N5Properties.java
+++ b/src/main/java/bdv/img/n5/N5Properties.java
@@ -46,5 +46,5 @@ public interface N5Properties
 
 	long[] getDimensions( N5Reader n5, int setupId, int timepointId, int level );
 
-	String getDatasetPath( int setupId, int timepointId, int level );
+	String getDatasetPath( N5Reader n5, int setupId, int timepointId, int level );
 }


### PR DESCRIPTION
This PR is a request to change the signature of the N5Properties .getDatasetPath API to have access to an N5Reader in order to read the actual dataset path instead of making assumptions that it will always be something like `dataset/0` or `dataset/S0`.
I had this problem in BigStitcher where I needed the  "multiscale" attribute from the OME metadata but that had not populated yet in the instance of the N5Properties I was using. So I needed to use n5Reader.getAttribute("multiscale") to get it, but I didn't have an N5Reader.

I can also think of cases where the dataset needed is burried in some deep group hierarchy and in order to get the proper attribute one needs access to an N5Reader.