### PR TITLE
n5-4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
 		<license.copyrightOwners>BigDataViewer developers.</license.copyrightOwners>
 
 		<imglib2-cache.version>1.0.0-beta-20</imglib2-cache.version>
+		<n5.version>4.0.0</n5.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/src/main/java/bdv/export/n5/WriteSequenceToN5.java
+++ b/src/main/java/bdv/export/n5/WriteSequenceToN5.java
@@ -291,15 +291,13 @@ public class WriteSequenceToN5
 			final String pathName = getPathName( setupId, timepointId, level );
 			try
 			{
-				n5.createDataset( pathName, dimensions, blockSize, dataType, compression );
+				final DatasetAttributes attributes = n5.createDataset( pathName, dimensions, blockSize, dataType, compression );
+				return new N5Dataset( pathName, attributes );
 			}
 			catch ( final N5Exception e )
 			{
 				throw new IOException( e );
 			}
-
-			final DatasetAttributes attributes = n5.getDatasetAttributes( pathName );
-			return new N5Dataset( pathName, attributes );
 		}
 
 		@Override


### PR DESCRIPTION
In the future, it would be useful to use `readChunk` / `readChunks`, to make reading more efficient for sharded datasets, but it appears that nothing needs to be done for bdv to be functional after this update.

A small beneficial change - this PR uses the `DatasetAttributes` returned by `N5Writer.createDataset`