### PR TITLE
Read chunks instead of blocks

### DIFF
--- a/src/main/java/bdv/img/n5/N5ImageLoader.java
+++ b/src/main/java/bdv/img/n5/N5ImageLoader.java
@@ -459,7 +459,7 @@ public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
 		{
 			final DatasetAttributes attributes = n5.getDatasetAttributes( datasetPath );
 			final long[] dimensions = attributes.getDimensions();
-			final int[] cellDimensions = attributes.getBlockSize();
+			final int[] cellDimensions = attributes.getChunkSize();
 			final CellGrid grid = new CellGrid( dimensions, cellDimensions );
 			final DataTypeProperties< ?, ?, ?, ? > dataTypeProperties = DataTypeProperties.of( attributes.getDataType() );
 			final SimpleCacheArrayLoader< ? > loader = new N5CacheArrayLoader<>( n5, datasetPath, attributes, dataTypeProperties );
@@ -512,7 +512,7 @@ public class N5ImageLoader implements ViewerImgLoader, MultiResolutionImgLoader
 			final DataBlock< T > dataBlock;
 			try
 			{
-				dataBlock = Cast.unchecked( n5.readBlock( pathName, attributes, gridPosition ) );
+				dataBlock = Cast.unchecked( n5.readChunk( pathName, attributes, gridPosition ) );
 			}
 			catch ( final N5Exception e )
 			{


### PR DESCRIPTION
This PR uses `n5.readChunk` instead of  `n5.readBlock` to improve reading efficiency for sharded Zarrv3 datasets. BigStitcher-Spark Zarrv3 dataset fusion often runs out of memory without this change.

Follows up on the comment by @bogovicj in https://github.com/bigdataviewer/bigdataviewer-core/pull/220.