### PR TITLE
add  RealTransformedSource

### DIFF
--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -1,0 +1,210 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies.
+ * %%
+ * Copyright (C) 2012 - 2022 BigDataViewer developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.tools.transformation;
+
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import bdv.viewer.Interpolation;
+import bdv.viewer.Source;
+import bdv.viewer.render.DefaultMipmapOrdering;
+import bdv.viewer.render.MipmapOrdering;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.InvertibleRealTransform;
+import net.imglib2.realtransform.RealTransform;
+import net.imglib2.realtransform.RealTransformRealRandomAccessible;
+import net.imglib2.realtransform.RealTransformSequence;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.RealIntervals;
+import net.imglib2.view.Views;
+
+/**
+ * A {@link Source} that wraps another {@link Source}, transforming it with a
+ * {@link InvertibleRealTransform}.
+ *
+ * @author John Bogovic
+ *
+ * @param <T> the type
+ */
+public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
+{
+	/**
+	 * The wrapped {@link Source}.
+	 */
+	private final Source< T > source;
+
+	private final String name;
+
+	/**
+	 * This is either the {@link #source} itself, if it implements
+	 * {@link MipmapOrdering}, or a {@link DefaultMipmapOrdering}.
+	 */
+	private final MipmapOrdering sourceMipmapOrdering;
+
+	private InvertibleRealTransform transform;
+
+	private final Supplier< Boolean > boundingBoxCullingSupplier;
+
+	private final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator;
+
+	public RealTransformedSource( final Source< T > source, final String name,
+			final InvertibleRealTransform transform )
+	{
+		this( source, name, transform,
+				(t,i) -> { return Intervals.smallestContainingInterval( 
+						RealIntervals.boundingIntervalFaces( i, t, 5 )); },
+				null );
+	}
+
+	public RealTransformedSource( final Source< T > source, final String name,
+		    final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator,
+			final InvertibleRealTransform transform )
+	{
+		this( source, name, transform, boundingBoxEstimator, null );
+	}
+
+	public RealTransformedSource( final Source< T > source, final String name,
+		    final InvertibleRealTransform transform,
+		    final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator,
+			final Supplier< Boolean > doBoundingBoxCulling )
+	{
+		this.source = source;
+		this.name = name;
+		this.boundingBoxEstimator = boundingBoxEstimator;
+		this.boundingBoxCullingSupplier = doBoundingBoxCulling;
+		setTransform( transform );
+
+		sourceMipmapOrdering = MipmapOrdering.class.isInstance( source ) ?
+				( MipmapOrdering ) source : new DefaultMipmapOrdering( source );
+	}
+
+	@Override
+	public boolean isPresent( final int t )
+	{
+		return source.isPresent( t );
+	}
+
+	@Override
+	public boolean doBoundingBoxCulling()
+	{
+		if( boundingBoxCullingSupplier != null )
+			return boundingBoxCullingSupplier.get();
+		else
+			return source.doBoundingBoxCulling();
+	}
+
+	public void setTransform( final InvertibleRealTransform transform )
+	{
+		this.transform = transform;
+	}
+
+	public Source< T > getWrappedSource()
+	{
+		return source;
+	}
+
+	@Override
+	public RandomAccessibleInterval< T > getSource( final int t, final int level )
+	{
+		// TODO expose interp method - it probably matters
+		@SuppressWarnings("unchecked")
+		final RealTransformRealRandomAccessible<T,?> interpSrc = (RealTransformRealRandomAccessible<T,?>)getInterpolatedSource( t, level, Interpolation.NEARESTNEIGHBOR );
+
+		final AffineTransform3D transform = new AffineTransform3D();
+		source.getSourceTransform( t, level, transform );
+		final RealTransformSequence totalInverseTransform = new RealTransformSequence();
+		totalInverseTransform.add( transform.inverse() );
+		totalInverseTransform.add( transform.inverse() );
+		totalInverseTransform.add( transform );
+		final Interval boundingInterval = boundingBoxEstimator.apply( totalInverseTransform, source.getSource( t, level ) );
+
+		return Views.interval( Views.raster(interpSrc), boundingInterval );
+	}
+
+	@Override
+	public RealRandomAccessible< T > getInterpolatedSource( final int t, final int level, final Interpolation method )
+	{
+		final RealRandomAccessible<T> realSrc = source.getInterpolatedSource( t, level, method );
+		final AffineTransform3D transform = new AffineTransform3D();
+		source.getSourceTransform( t, level, transform );
+
+		final RealTransformSequence totalTransform = new RealTransformSequence();
+		totalTransform.add( transform );
+		totalTransform.add( transform );
+		totalTransform.add( transform.inverse() );
+
+		return new RealTransformRealRandomAccessible< T, RealTransform >( realSrc, totalTransform );
+	}
+
+	@Override
+	public synchronized void getSourceTransform( final int t, final int level, final AffineTransform3D transform )
+	{
+		source.getSourceTransform( t, level, transform );
+	}
+
+	public InvertibleRealTransform getTransform()
+	{
+		return transform;
+	}
+
+	@Override
+	public T getType()
+	{
+		return source.getType();
+	}
+
+	@Override
+	public String getName()
+	{
+		return name;
+	}
+
+	@Override
+	public VoxelDimensions getVoxelDimensions()
+	{
+		return source.getVoxelDimensions();
+	}
+
+	@Override
+	public int getNumMipmapLevels()
+	{
+		return source.getNumMipmapLevels();
+	}
+
+	@Override
+	public synchronized MipmapHints getMipmapHints( final AffineTransform3D screenTransform, final int timepoint, final int previousTimepoint )
+	{
+		return sourceMipmapOrdering.getMipmapHints( screenTransform, timepoint, previousTimepoint );
+	}
+
+}

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -72,8 +72,8 @@ import net.imglib2.view.Views;
  * <p>
  * The provided transformation must be the inverse transformation - taking
  * pixels from target space to source space (see
- * {@link RealTransformRealRandomAccessible). Note this is the opposite convention
- * as used by {@code TransformedSource}. 
+ * {@link RealTransformRealRandomAccessible}). Note this is the opposite convention
+ * as used by {@code TransformedSource}.
  * <p>
  * The bounding intervals for each mipmap level are estimated using the passed
  * {@code boundingBoxEstimator}, using {@link FacesSteps} with 5 steps as the

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -121,7 +121,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	/**
 	 * Wraps {@code source} with the given world-coordinate {@code transform},
 	 * using a default bounding-box estimator that samples the interval faces
-	 * (10 steps per axis) and inherits bounding-box culling from {@code source}.
+	 * (5 steps per axis) and inherits bounding-box culling from {@code source}.
 	 *
 	 * @param source
 	 *            the source to warp
@@ -201,18 +201,22 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	}
 
 	/**
-	 * Sets the world-coordinate transform to apply and (re)builds the per-mipmap-level
-	 * caches derived from it.
+	 * Sets the world-coordinate transform to apply and (re)builds the
+	 * per-mipmap-level caches derived from it.
 	 * <p>
 	 * For each level a total transform sequence is precomputed that maps that
 	 * level's pixel coordinates to world via the source transform, applies a
-	 * {@link InvertibleRealTransform#copy() copy} of {@code transform}, then maps
-	 * back to pixels; a copy is used so each sequence has its own instance. The
-	 * bounding interval that {@link #getSource} rasterizes over is estimated once
-	 * per level (at timepoint {@code 0}) using the {@code boundingBoxEstimator}.
+	 * {@link RealTransform#copy() copy} of {@code transform}, then
+	 * maps back to pixels; a copy is used so each sequence has its own
+	 * instance. The bounding interval that {@link #getSource} rasterizes over
+	 * is estimated once per level (at timepoint {@code 0}) using the
+	 * {@code boundingBoxEstimator}.
 	 *
 	 * @param transform
 	 *            the transform to apply, in world coordinates
+	 * @param boundingBoxEstimator
+	 *            used to find the new bounding box after applying the
+	 *            transformation
 	 */
 	public void setTransform( final RealTransform transform, BiFunction<RealTransform, RealInterval, RealInterval> boundingBoxEstimator)
 	{
@@ -239,6 +243,15 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 		boundingIntervals = intervals;
 	}
 
+	/**
+	 * Sets the world-coordinate transform to apply and (re)builds the
+	 * per-mipmap-level caches derived from it, using a default bounding-box
+	 * estimator appropriate for the given transform (see
+	 * {@link #appropriateEstimator}).
+	 *
+	 * @param transform
+	 *            the transform to apply, in world coordinates
+	 */
 	public void setTransform(final RealTransform transform) {
 
 		// create an appropriate BiFunction for this class of transform
@@ -251,10 +264,10 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	 * the transform is affine, in which case it uses {@link Corners}.
 	 *
 	 * @param transform
-	 * 	the transform
+	 *            the transform
 	 * @param numStepsLongestDimension
-	 * 	if needed, the number of steps 
-	 * @return
+	 *            if needed, the number of steps
+	 * @return a bounding-box estimator appropriate for the transform
 	 */
 	private static BiFunction<RealTransform, RealInterval, RealInterval> appropriateEstimator(
 			final RealTransform transform, int numStepsLongestDimension) {
@@ -280,10 +293,13 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	 * that the largest dimensions has the specified number of steps. Other
 	 * dimensions should have a number of steps that has the same spacing as the
 	 * longest dimension. At least two points are sampled for every dimension.
-	 * 
+	 *
 	 * @param interval
+	 *            the interval whose per-dimension widths set the step counts
 	 * @param numStepsLongestDimension
-	 * @return
+	 *            the number of steps to sample along the longest dimension
+	 * @return a {@link FacesSteps} sampler with per-dimension step counts
+	 *         proportional to each dimension's width
 	 */
 	private static FacesSteps facesEstimator( RealInterval interval, int numStepsLongestDimension ) {
 
@@ -315,46 +331,46 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 
 	/**
 	 * Estimates the world-space {@link RealInterval} that results from mapping
-	 * a pixel {@code interval} to world coordinates with the affine {@code a},
-	 * warping it with the general transform {@code t}, then mapping back to
-	 * pixel coordinates with the inverse of {@code a}.
+	 * a pixel interval to world coordinates with the affine {@code pixelToPhysical},
+	 * warping it with the inverse of {@code transform}, then mapping back to
+	 * pixel coordinates with the inverse of {@code pixelToPhysical}.
+	 * <p>
+	 * If {@code transform} is not an {@link InvertibleRealTransform}, the inverse
+	 * is esimated with a {@link WrappedIterativeInvertibleRealTransform}.
 	 * <p>
 	 * The affine legs are bounded exactly using their corners; only the
-	 * (potentially non-linear) transform {@code t} is estimated by sampling the
-	 * interval faces, with {@code numStepsLongestDimension} steps along the
-	 * longest dimension.
+	 * (potentially non-linear) transform {@code transform} is estimated 
+	 * using {@code boundingBoxEstimator}.
 	 * <p>
-	 * This method is used so that the provided boundingBoxUpdater can be
+	 * This method is used so that the provided {@code boundingBoxEstimator} can be
 	 * applied to only the world transformation, ignoring the pixelToPhysical
 	 * transformation. Without this, faces bounding box estimator would not be
 	 * able to take into account the physical bounding box.
 	 *
-	 * @param a
+	 * @param pixelToPhysical 
 	 *            the affine mapping pixel to world coordinates
-	 * @param boundingBoxUpdater
+	 * @param boundingBoxEstimator
 	 *            function estimating a bounding box from a transformation
-	 * @param t
+	 * @param transform
 	 *            the general transform applied in world coordinates
 	 * @param interval
 	 *            the pixel interval
-	 * @param numStepsLongestDimension
-	 *            number of face-sampling steps along the longest dimension
 	 * @return the estimated pixel-space bounding interval
 	 */
 	private static RealInterval estimateBounds(
 			final AffineTransform3D pixelToPhysical,
 			final BiFunction<RealTransform, RealInterval, RealInterval> boundingBoxEstimator,
-			final RealTransform t,
-			final Interval interval)
+			final RealTransform transform,
+			final RealInterval interval)
 	{
 		/**
 		 * The total forward transformation needed for bounding box estimation is:
 		 * pixelToPhysical
-		 * t.inverse
+		 * transform.inverse
 		 * pixelToPhysical.inverse
 		 */
 		final RealInterval physical = pixelToPhysical.estimateBounds(interval);
-		final RealInterval transformedPhysical = boundingBoxEstimator.apply(directOrEstimatedInverse(t), physical);
+		final RealInterval transformedPhysical = boundingBoxEstimator.apply(directOrEstimatedInverse(transform), physical);
 		final FinalRealInterval transformedPixel = pixelToPhysical.inverse().estimateBounds(transformedPhysical);
 		return transformedPixel;
 	}

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -61,10 +61,15 @@ import net.imglib2.view.Views;
  * The supplied transform is interpreted in the world coordinate system that the
  * wrapped source maps into via its {@link Source#getSourceTransform
  * getSourceTransform}. Since the images returned by {@link #getSource} and
- * {@@link #getInterpolatedSource} are expected to be in the scale levels' pixel
+ * {@link #getInterpolatedSource} are expected to be in the scale levels' pixel
  * coordinates, this class internally maps pixel coordinate to world coordinates
  * before applying the provided transformation, then maps back to pixel
  * coordinates.
+ * <p>
+ * The inverse direction of the provided transformation is used for pixel
+ * renderings, and therefore should be fast. The forward direction is used only
+ * for bounding interval estimation. If one direction of the provided transform
+ * is iteratively estimated, callers should ensure it is the inverse direction.
  * <p>
  * The bounding intervals for each mipmap level are estimated using the passed
  * {@code boundingBoxEstimator}, using {@link FacesSteps} with 10 steps as the

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -2,7 +2,7 @@
  * #%L
  * BigDataViewer core classes with minimal dependencies.
  * %%
- * Copyright (C) 2012 - 2022 BigDataViewer developers.
+ * Copyright (C) 2012 - 2026 BigDataViewer developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,9 @@
  */
 package bdv.tools.transformation;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -41,51 +44,112 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.InvertibleRealTransform;
+import net.imglib2.realtransform.InvertibleRealTransformSequence;
 import net.imglib2.realtransform.RealTransform;
 import net.imglib2.realtransform.RealTransformRealRandomAccessible;
-import net.imglib2.realtransform.RealTransformSequence;
+import net.imglib2.realtransform.interval.FacesSteps;
+import net.imglib2.realtransform.interval.IntervalSamplingMethod;
 import net.imglib2.util.Intervals;
-import net.imglib2.util.RealIntervals;
 import net.imglib2.view.Views;
 
 /**
- * A {@link Source} that wraps another {@link Source}, transforming it with a
- * {@link InvertibleRealTransform}.
+ * A {@link Source} that wraps another {@link Source} and warps it with an
+ * {@link InvertibleRealTransform} applied in <em>world</em> coordinates. This
+ * class is intended for use with general, potentially non-affine
+ * transformations. For affines, use {@link TransformedSource}.
+ * <p>
+ * The supplied transform is interpreted in the world coordinate system that the
+ * wrapped source maps into via its {@link Source#getSourceTransform
+ * getSourceTransform}. Since the images returned by {@link #getSource} and
+ * {@@link #getInterpolatedSource} are expected to be in the scale levels' pixel
+ * coordinates, this class internally maps pixel coordinate to world coordinates
+ * before applying the provided transformation, then maps back to pixel
+ * coordinates.
+ * <p>
+ * The bounding intervals for each mipmap level are estimated using the passed
+ * {@code boundingBoxEstimator}, using {@link FacesSteps} with 10 steps as the
+ * default.
  *
- * @author John Bogovic
- *
- * @param <T> the type
+ * @param <T>
+ *            the type of the original source
  */
-public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
-{
-	/**
-	 * The wrapped {@link Source}.
-	 */
-	private final Source< T > source;
+public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
+	protected final Source< T > source;
 
-	private final String name;
+	/**
+	 * optional new name. if null, the name of the original source will be used.
+	 */
+	protected final String name;
 
 	/**
 	 * This is either the {@link #source} itself, if it implements
 	 * {@link MipmapOrdering}, or a {@link DefaultMipmapOrdering}.
 	 */
-	private final MipmapOrdering sourceMipmapOrdering;
+	protected final MipmapOrdering sourceMipmapOrdering;
 
-	private InvertibleRealTransform transform;
+	/**
+	 * The transformation to apply.
+	 */
+	protected InvertibleRealTransform transform;
+
+	/**
+	 * Pre-computed total transform, one per mipmap level. For each level, the
+	 * sequence takes that level's pixel coordinates to world via the source
+	 * transform, applies {@link #transform}, then maps back. Rebuilt whenever
+	 * {@link #setTransform} is called.
+	 */
+	private List< InvertibleRealTransformSequence > transformSequences;
+
+	/**
+	 * Pre-computed bounding interval for {@link #getSource}, one per mipmap
+	 * level. Rebuilt whenever {@link #setTransform} is called, using timepoint
+	 * {@code 0}.
+	 */
+	private List< Interval > boundingIntervals;
 
 	private final Supplier< Boolean > boundingBoxCullingSupplier;
 
 	private final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator;
 
+	/**
+	 * Wraps {@code source} with the given world-coordinate {@code transform},
+	 * using a default bounding-box estimator that samples the interval faces
+	 * (10 steps per axis) and inherits bounding-box culling from {@code source}.
+	 *
+	 * @param source
+	 *            the source to warp
+	 * @param name
+	 *            optional new name; if {@code null} the wrapped source's name is used
+	 * @param transform
+	 *            the transform to apply, in world coordinates
+	 */
 	public RealTransformedSource( final Source< T > source, final String name,
 			final InvertibleRealTransform transform )
 	{
 		this( source, name, transform,
-				(t,i) -> { return Intervals.smallestContainingInterval( 
-						RealIntervals.boundingIntervalFaces( i, t, 5 )); },
+				(t, i) -> {
+					return Intervals.smallestContainingInterval(
+							t.boundingInterval(i, facesIsotropicSteps(i.numDimensions(), 10)));
+				},
 				null );
 	}
 
+	/**
+	 * Wraps {@code source} with the given world-coordinate {@code transform},
+	 * using the suppliued bounding-box estimator, and inherits bounding-box
+	 * culling from {@code source}.
+	 *
+	 * @param source
+	 *            the source to warp
+	 * @param name
+	 *            optional new name; if {@code null} the wrapped source's name
+	 *            is used
+	 * @param boundingBoxEstimator
+	 *            estimates the world-space interval that {@link #getSource}
+	 *            rasterizes over, given the transform and the wrapped interval
+	 * @param transform
+	 *            the transform to apply, in world coordinates
+	 */
 	public RealTransformedSource( final Source< T > source, final String name,
 		    final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator,
 			final InvertibleRealTransform transform )
@@ -93,6 +157,22 @@ public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
 		this( source, name, transform, boundingBoxEstimator, null );
 	}
 
+	/**
+	 * Wraps {@code source} with the given world-coordinate {@code transform}.
+	 *
+	 * @param source
+	 *            the source to warp
+	 * @param name
+	 *            optional new name; if {@code null} the wrapped source's name is used
+	 * @param transform
+	 *            the transform to apply, in world coordinates
+	 * @param boundingBoxEstimator
+	 *            estimates the world-space interval that {@link #getSource}
+	 *            rasterizes over, given the transform and the wrapped interval
+	 * @param doBoundingBoxCulling
+	 *            supplies the value returned by {@link #doBoundingBoxCulling()};
+	 *            if {@code null}, the wrapped source's setting is used
+	 */
 	public RealTransformedSource( final Source< T > source, final String name,
 		    final InvertibleRealTransform transform,
 		    final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator,
@@ -123,9 +203,42 @@ public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
 			return source.doBoundingBoxCulling();
 	}
 
+	/**
+	 * Sets the world-coordinate transform to apply and (re)builds the per-mipmap-level
+	 * caches derived from it.
+	 * <p>
+	 * For each level a total transform sequence is precomputed that maps that
+	 * level's pixel coordinates to world via the source transform, applies a
+	 * {@link InvertibleRealTransform#copy() copy} of {@code transform}, then maps
+	 * back to pixels; a copy is used so each sequence has its own instance. The
+	 * bounding interval that {@link #getSource} rasterizes over is estimated once
+	 * per level (at timepoint {@code 0}) using the {@code boundingBoxEstimator}.
+	 *
+	 * @param transform
+	 *            the transform to apply, in world coordinates
+	 */
 	public void setTransform( final InvertibleRealTransform transform )
 	{
 		this.transform = transform;
+
+		final int numLevels = getNumMipmapLevels();
+		final List< InvertibleRealTransformSequence > sequences = new ArrayList<>( numLevels );
+		final List< Interval > intervals = new ArrayList<>( numLevels );
+		for ( int level = 0; level < numLevels; level++ )
+		{
+			final AffineTransform3D affine = new AffineTransform3D();
+			source.getSourceTransform( 0, level, affine );
+
+			final InvertibleRealTransformSequence seq = new InvertibleRealTransformSequence();
+			seq.add( affine );
+			seq.add( transform.copy() );
+			seq.add( affine.inverse() );
+			sequences.add( seq );
+
+			intervals.add( boundingBoxEstimator.apply( seq, source.getSource( 0, level ) ) );
+		}
+		transformSequences = sequences;
+		boundingIntervals = intervals;
 	}
 
 	public Source< T > getWrappedSource()
@@ -137,33 +250,15 @@ public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
 	public RandomAccessibleInterval< T > getSource( final int t, final int level )
 	{
 		// TODO expose interp method - it probably matters
-		@SuppressWarnings("unchecked")
-		final RealTransformRealRandomAccessible<T,?> interpSrc = (RealTransformRealRandomAccessible<T,?>)getInterpolatedSource( t, level, Interpolation.NEARESTNEIGHBOR );
-
-		final AffineTransform3D transform = new AffineTransform3D();
-		source.getSourceTransform( t, level, transform );
-		final RealTransformSequence totalInverseTransform = new RealTransformSequence();
-		totalInverseTransform.add( transform.inverse() );
-		totalInverseTransform.add( transform.inverse() );
-		totalInverseTransform.add( transform );
-		final Interval boundingInterval = boundingBoxEstimator.apply( totalInverseTransform, source.getSource( t, level ) );
-
-		return Views.interval( Views.raster(interpSrc), boundingInterval );
+		final RealRandomAccessible<T> interpSrc = getInterpolatedSource( t, level, Interpolation.NEARESTNEIGHBOR );
+		return Views.interval( Views.raster(interpSrc), boundingIntervals.get( level ) );
 	}
 
 	@Override
 	public RealRandomAccessible< T > getInterpolatedSource( final int t, final int level, final Interpolation method )
 	{
 		final RealRandomAccessible<T> realSrc = source.getInterpolatedSource( t, level, method );
-		final AffineTransform3D transform = new AffineTransform3D();
-		source.getSourceTransform( t, level, transform );
-
-		final RealTransformSequence totalTransform = new RealTransformSequence();
-		totalTransform.add( transform );
-		totalTransform.add( transform );
-		totalTransform.add( transform.inverse() );
-
-		return new RealTransformRealRandomAccessible< T, RealTransform >( realSrc, totalTransform );
+		return new RealTransformRealRandomAccessible< T, RealTransform >( realSrc, transformSequences.get( level ).inverse() );
 	}
 
 	@Override
@@ -186,7 +281,8 @@ public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
 	@Override
 	public String getName()
 	{
-		return name;
+		if ( name != null ) return name;
+		else return source.getName();
 	}
 
 	@Override
@@ -205,6 +301,12 @@ public class RealTransformedSource < T > implements Source< T >, MipmapOrdering
 	public synchronized MipmapHints getMipmapHints( final AffineTransform3D screenTransform, final int timepoint, final int previousTimepoint )
 	{
 		return sourceMipmapOrdering.getMipmapHints( screenTransform, timepoint, previousTimepoint );
+	}
+
+	private static IntervalSamplingMethod facesIsotropicSteps( int nd, long step)  {
+		final long[] steps = new long[nd];
+		Arrays.fill(steps, step);
+		return new FacesSteps(steps);
 	}
 
 }

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -29,7 +29,6 @@
 package bdv.tools.transformation;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -39,24 +38,29 @@ import bdv.viewer.Source;
 import bdv.viewer.render.DefaultMipmapOrdering;
 import bdv.viewer.render.MipmapOrdering;
 import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealInterval;
 import net.imglib2.RealRandomAccessible;
+import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.InvertibleRealTransform;
-import net.imglib2.realtransform.InvertibleRealTransformSequence;
 import net.imglib2.realtransform.RealTransform;
 import net.imglib2.realtransform.RealTransformRealRandomAccessible;
+import net.imglib2.realtransform.RealTransformSequence;
+import net.imglib2.realtransform.interval.Corners;
 import net.imglib2.realtransform.interval.FacesSteps;
 import net.imglib2.realtransform.interval.IntervalSamplingMethod;
+import net.imglib2.realtransform.inverse.WrappedIterativeInvertibleRealTransform;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
 /**
  * A {@link Source} that wraps another {@link Source} and warps it with an
- * {@link InvertibleRealTransform} applied in <em>world</em> coordinates. This
- * class is intended for use with general, potentially non-affine
- * transformations. For affines, use {@link TransformedSource}.
+ * {@link RealTransform} applied in <em>world</em> coordinates. This class is
+ * intended for use with general, potentially non-affine transformations. For
+ * affines, use {@link TransformedSource}.
  * <p>
  * The supplied transform is interpreted in the world coordinate system that the
  * wrapped source maps into via its {@link Source#getSourceTransform
@@ -66,19 +70,20 @@ import net.imglib2.view.Views;
  * before applying the provided transformation, then maps back to pixel
  * coordinates.
  * <p>
- * The inverse direction of the provided transformation is used for pixel
- * renderings, and therefore should be fast. The forward direction is used only
- * for bounding interval estimation. If one direction of the provided transform
- * is iteratively estimated, callers should ensure it is the inverse direction.
+ * The provided transformation must be the inverse transformation - taking
+ * pixels from target space to source space (see
+ * {@link RealTransformRealRandomAccessible). Note this is the opposite convention
+ * as used by {@code TransformedSource}. 
  * <p>
  * The bounding intervals for each mipmap level are estimated using the passed
- * {@code boundingBoxEstimator}, using {@link FacesSteps} with 10 steps as the
+ * {@code boundingBoxEstimator}, using {@link FacesSteps} with 5 steps as the
  * default.
  *
  * @param <T>
  *            the type of the original source
  */
-public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
+public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
+{
 	protected final Source< T > source;
 
 	/**
@@ -95,7 +100,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	/**
 	 * The transformation to apply.
 	 */
-	protected InvertibleRealTransform transform;
+	protected RealTransform transform;
 
 	/**
 	 * Pre-computed total transform, one per mipmap level. For each level, the
@@ -103,7 +108,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	 * transform, applies {@link #transform}, then maps back. Rebuilt whenever
 	 * {@link #setTransform} is called.
 	 */
-	private List< InvertibleRealTransformSequence > transformSequences;
+	private List< RealTransformSequence > transformSequences;
 
 	/**
 	 * Pre-computed bounding interval for {@link #getSource}, one per mipmap
@@ -113,8 +118,6 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	private List< Interval > boundingIntervals;
 
 	private final Supplier< Boolean > boundingBoxCullingSupplier;
-
-	private final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator;
 
 	/**
 	 * Wraps {@code source} with the given world-coordinate {@code transform},
@@ -129,14 +132,9 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	 *            the transform to apply, in world coordinates
 	 */
 	public RealTransformedSource( final Source< T > source, final String name,
-			final InvertibleRealTransform transform )
+			final RealTransform transform )
 	{
-		this( source, name, transform,
-				(t, i) -> {
-					return Intervals.smallestContainingInterval(
-							t.boundingInterval(i, facesIsotropicSteps(i.numDimensions(), 10)));
-				},
-				null );
+		this( source, name, transform, appropriateEstimator(transform, 5), null );
 	}
 
 	/**
@@ -156,8 +154,8 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	 *            the transform to apply, in world coordinates
 	 */
 	public RealTransformedSource( final Source< T > source, final String name,
-		    final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator,
-			final InvertibleRealTransform transform )
+		    final BiFunction< RealTransform, RealInterval, RealInterval > boundingBoxEstimator,
+			final RealTransform transform )
 	{
 		this( source, name, transform, boundingBoxEstimator, null );
 	}
@@ -179,15 +177,14 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	 *            if {@code null}, the wrapped source's setting is used
 	 */
 	public RealTransformedSource( final Source< T > source, final String name,
-		    final InvertibleRealTransform transform,
-		    final BiFunction< RealTransform, Interval, Interval > boundingBoxEstimator,
+		    final RealTransform transform,
+		    final BiFunction< RealTransform, RealInterval, RealInterval > boundingBoxEstimator,
 			final Supplier< Boolean > doBoundingBoxCulling )
 	{
 		this.source = source;
 		this.name = name;
-		this.boundingBoxEstimator = boundingBoxEstimator;
 		this.boundingBoxCullingSupplier = doBoundingBoxCulling;
-		setTransform( transform );
+		setTransform( transform, boundingBoxEstimator );
 
 		sourceMipmapOrdering = MipmapOrdering.class.isInstance( source ) ?
 				( MipmapOrdering ) source : new DefaultMipmapOrdering( source );
@@ -222,28 +219,162 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	 * @param transform
 	 *            the transform to apply, in world coordinates
 	 */
-	public void setTransform( final InvertibleRealTransform transform )
+	public void setTransform( final RealTransform transform, BiFunction<RealTransform, RealInterval, RealInterval> boundingBoxEstimator)
 	{
 		this.transform = transform;
 
 		final int numLevels = getNumMipmapLevels();
-		final List< InvertibleRealTransformSequence > sequences = new ArrayList<>( numLevels );
+		final List< RealTransformSequence > sequences = new ArrayList<>( numLevels );
 		final List< Interval > intervals = new ArrayList<>( numLevels );
 		for ( int level = 0; level < numLevels; level++ )
 		{
 			final AffineTransform3D affine = new AffineTransform3D();
 			source.getSourceTransform( 0, level, affine );
 
-			final InvertibleRealTransformSequence seq = new InvertibleRealTransformSequence();
+			final RealTransformSequence seq = new RealTransformSequence();
 			seq.add( affine );
 			seq.add( transform.copy() );
 			seq.add( affine.inverse() );
 			sequences.add( seq );
 
-			intervals.add( boundingBoxEstimator.apply( seq, source.getSource( 0, level ) ) );
+			intervals.add(Intervals.smallestContainingInterval(
+					estimateBounds(affine, boundingBoxEstimator, transform, source.getSource(0, level))));
 		}
 		transformSequences = sequences;
 		boundingIntervals = intervals;
+	}
+
+	public void setTransform(final RealTransform transform) {
+
+		// create an appropriate BiFunction for this class of transform
+		setTransform(transform, appropriateEstimator(transform, 5));
+	}
+	
+	/**
+	 * Return an appropriate bounding box estimator for the given transform.
+	 * Uses a {@link FacesSteps} instance with the given number of steps, unless
+	 * the transform is affine, in which case it uses {@link Corners}.
+	 *
+	 * @param transform
+	 * 	the transform
+	 * @param numStepsLongestDimension
+	 * 	if needed, the number of steps 
+	 * @return
+	 */
+	private static BiFunction<RealTransform, RealInterval, RealInterval> appropriateEstimator(
+			final RealTransform transform, int numStepsLongestDimension) {
+
+		/**
+		 * TODO drop this in favor of an identical method in imglib2-realtransform
+		 * once an equivalent is available there.
+		 */
+		final BiFunction<RealTransform, RealInterval, RealInterval> estimator = (t, i) -> {
+			if (t instanceof AffineGet) {
+				// some AffineGet implementations ignore the IntervalSamplingMethod,
+				// but even if used, CORNERS is appropriate for an affine
+				return ((AffineGet)t).boundingInterval(i, IntervalSamplingMethod.CORNERS);
+			}
+
+			return facesEstimator(i, numStepsLongestDimension).bounds(i, t);
+		};
+		return estimator;
+	}
+
+	/**
+	 * Returns an {@link FacesSteps} interval sampler with steps chosen such
+	 * that the largest dimensions has the specified number of steps. Other
+	 * dimensions should have a number of steps that has the same spacing as the
+	 * longest dimension. At least two points are sampled for every dimension.
+	 * 
+	 * @param interval
+	 * @param numStepsLongestDimension
+	 * @return
+	 */
+	private static FacesSteps facesEstimator( RealInterval interval, int numStepsLongestDimension ) {
+
+		final int nd = interval.numDimensions();
+
+		double longestWidth = 0.0;
+		for ( int i = 0; i < nd; i++ )
+		{
+			final double w = interval.realMax( i ) - interval.realMin( i );
+			if ( w > longestWidth )
+				longestWidth = w;
+		}
+
+		// the step spacing that yields numStepsLongestDimension steps along the
+		// longest dimension; other dimensions use the same spacing so that the
+		// number of steps is proportional to their width.
+		final double spacing = longestWidth / numStepsLongestDimension;
+
+		final long[] steps = new long[ nd ];
+		for ( int i = 0; i < nd; i++ )
+		{
+			final double w = interval.realMax( i ) - interval.realMin( i );
+			// at least one step (two sampled points) per dimension
+			steps[ i ] = spacing > 0 ? Math.max( 1, Math.round( w / spacing ) ) : 1;
+		}
+
+		return new FacesSteps( steps );
+	}
+
+	/**
+	 * Estimates the world-space {@link RealInterval} that results from mapping
+	 * a pixel {@code interval} to world coordinates with the affine {@code a},
+	 * warping it with the general transform {@code t}, then mapping back to
+	 * pixel coordinates with the inverse of {@code a}.
+	 * <p>
+	 * The affine legs are bounded exactly using their corners; only the
+	 * (potentially non-linear) transform {@code t} is estimated by sampling the
+	 * interval faces, with {@code numStepsLongestDimension} steps along the
+	 * longest dimension.
+	 * <p>
+	 * This method is used so that the provided boundingBoxUpdater can be
+	 * applied to only the world transformation, ignoring the pixelToPhysical
+	 * transformation. Without this, faces bounding box estimator would not be
+	 * able to take into account the physical bounding box.
+	 *
+	 * @param a
+	 *            the affine mapping pixel to world coordinates
+	 * @param boundingBoxUpdater
+	 *            function estimating a bounding box from a transformation
+	 * @param t
+	 *            the general transform applied in world coordinates
+	 * @param interval
+	 *            the pixel interval
+	 * @param numStepsLongestDimension
+	 *            number of face-sampling steps along the longest dimension
+	 * @return the estimated pixel-space bounding interval
+	 */
+	private static RealInterval estimateBounds(
+			final AffineTransform3D pixelToPhysical,
+			final BiFunction<RealTransform, RealInterval, RealInterval> boundingBoxEstimator,
+			final RealTransform t,
+			final Interval interval)
+	{
+		/**
+		 * The total forward transformation needed for bounding box estimation is:
+		 * pixelToPhysical
+		 * t.inverse
+		 * pixelToPhysical.inverse
+		 */
+		final RealInterval physical = pixelToPhysical.estimateBounds(interval);
+		final RealInterval transformedPhysical = boundingBoxEstimator.apply(directOrEstimatedInverse(t), physical);
+		final FinalRealInterval transformedPixel = pixelToPhysical.inverse().estimateBounds(transformedPhysical);
+		return transformedPixel;
+	}
+
+	private static RealTransform directOrEstimatedInverse(RealTransform transform) {
+
+		return makeInvertible(transform).inverse();
+	}
+
+	private static InvertibleRealTransform makeInvertible(RealTransform transform) {
+
+		if (transform instanceof InvertibleRealTransform)
+			return ((InvertibleRealTransform)transform);
+
+		return new WrappedIterativeInvertibleRealTransform<>(transform);
 	}
 
 	public Source< T > getWrappedSource()
@@ -254,16 +385,16 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	@Override
 	public RandomAccessibleInterval< T > getSource( final int t, final int level )
 	{
-		// TODO expose interp method - it probably matters
-		final RealRandomAccessible<T> interpSrc = getInterpolatedSource( t, level, Interpolation.NEARESTNEIGHBOR );
-		return Views.interval( Views.raster(interpSrc), boundingIntervals.get( level ) );
+		// TODO expose interp method? 
+		final RealRandomAccessible< T > interpSrc = getInterpolatedSource( t, level, Interpolation.NEARESTNEIGHBOR );
+		return Views.interval( Views.raster( interpSrc ), boundingIntervals.get( level ) );
 	}
 
 	@Override
 	public RealRandomAccessible< T > getInterpolatedSource( final int t, final int level, final Interpolation method )
 	{
 		final RealRandomAccessible<T> realSrc = source.getInterpolatedSource( t, level, method );
-		return new RealTransformRealRandomAccessible< T, RealTransform >( realSrc, transformSequences.get( level ).inverse() );
+		return new RealTransformRealRandomAccessible< T, RealTransform >( realSrc, transformSequences.get( level ) );
 	}
 
 	@Override
@@ -272,7 +403,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 		source.getSourceTransform( t, level, transform );
 	}
 
-	public InvertibleRealTransform getTransform()
+	public RealTransform getTransform()
 	{
 		return transform;
 	}
@@ -306,12 +437,6 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering {
 	public synchronized MipmapHints getMipmapHints( final AffineTransform3D screenTransform, final int timepoint, final int previousTimepoint )
 	{
 		return sourceMipmapOrdering.getMipmapHints( screenTransform, timepoint, previousTimepoint );
-	}
-
-	private static IntervalSamplingMethod facesIsotropicSteps( int nd, long step)  {
-		final long[] steps = new long[nd];
-		Arrays.fill(steps, step);
-		return new FacesSteps(steps);
 	}
 
 }

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -31,7 +31,6 @@ package bdv.tools.transformation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
@@ -117,7 +116,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	 */
 	private List< Interval > boundingIntervals;
 
-	private final Supplier< Boolean > boundingBoxCullingSupplier;
+	private final boolean doBoundingBoxCulling;
 
 	/**
 	 * Wraps {@code source} with the given world-coordinate {@code transform},
@@ -139,7 +138,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 
 	/**
 	 * Wraps {@code source} with the given world-coordinate {@code transform},
-	 * using the suppliued bounding-box estimator, and inherits bounding-box
+	 * using the supplied bounding-box estimator, and inherits bounding-box
 	 * culling from {@code source}.
 	 *
 	 * @param source
@@ -173,17 +172,16 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	 *            estimates the world-space interval that {@link #getSource}
 	 *            rasterizes over, given the transform and the wrapped interval
 	 * @param doBoundingBoxCulling
-	 *            supplies the value returned by {@link #doBoundingBoxCulling()};
-	 *            if {@code null}, the wrapped source's setting is used
+	 *            if null, the wrapped source's setting is used
 	 */
 	public RealTransformedSource( final Source< T > source, final String name,
 		    final RealTransform transform,
 		    final BiFunction< RealTransform, RealInterval, RealInterval > boundingBoxEstimator,
-			final Supplier< Boolean > doBoundingBoxCulling )
+			final Boolean doBoundingBoxCulling )
 	{
 		this.source = source;
 		this.name = name;
-		this.boundingBoxCullingSupplier = doBoundingBoxCulling;
+		this.doBoundingBoxCulling = doBoundingBoxCulling == null ? source.doBoundingBoxCulling() : doBoundingBoxCulling;
 		setTransform( transform, boundingBoxEstimator );
 
 		sourceMipmapOrdering = MipmapOrdering.class.isInstance( source ) ?
@@ -199,10 +197,7 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 	@Override
 	public boolean doBoundingBoxCulling()
 	{
-		if( boundingBoxCullingSupplier != null )
-			return boundingBoxCullingSupplier.get();
-		else
-			return source.doBoundingBoxCulling();
+		return doBoundingBoxCulling;
 	}
 
 	/**

--- a/src/main/java/bdv/tools/transformation/RealTransformedSource.java
+++ b/src/main/java/bdv/tools/transformation/RealTransformedSource.java
@@ -280,9 +280,8 @@ public class RealTransformedSource<T> implements Source<T>, MipmapOrdering
 			if (t instanceof AffineGet) {
 				// some AffineGet implementations ignore the IntervalSamplingMethod,
 				// but even if used, CORNERS is appropriate for an affine
-				return ((AffineGet)t).boundingInterval(i, IntervalSamplingMethod.CORNERS);
+				return t.boundingInterval(i, IntervalSamplingMethod.CORNERS);
 			}
-
 			return facesEstimator(i, numStepsLongestDimension).bounds(i, t);
 		};
 		return estimator;

--- a/src/test/java/bdv/tools/transformation/RealTransformedSourceTest.java
+++ b/src/test/java/bdv/tools/transformation/RealTransformedSourceTest.java
@@ -1,0 +1,112 @@
+package bdv.tools.transformation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import bdv.util.RandomAccessibleIntervalSource;
+import bdv.viewer.Interpolation;
+import net.imglib2.Cursor;
+import net.imglib2.FinalRealInterval;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.iterator.LocalizingRealIntervalIterator;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.RealViews;
+import net.imglib2.type.numeric.real.DoubleType;
+
+public class RealTransformedSourceTest
+{
+	private static final double EPSILON = 1e-9;
+
+	/** Identity pixel calibration. */
+	@Test
+	public void testAffineMatchesTransformedSource()
+	{
+		final RandomAccessibleIntervalSource< DoubleType > base = exampleImg( new AffineTransform3D() );
+		assertSourcesMatch( base, exampleAffine() );
+	}
+
+	/** Non-identity calibration, with a different scale in each dimension. */
+	@Test
+	public void testAffineMatchesTransformedSourceWithCalibration()
+	{
+		final AffineTransform3D calibration = new AffineTransform3D();
+		calibration.scale( 2.0, 3.0, 4.0 );
+
+		final RandomAccessibleIntervalSource< DoubleType > base = exampleImg( calibration );
+		assertSourcesMatch( base, exampleAffine() );
+	}
+
+	/**
+	 * Asserts that a {@link RealTransformedSource} and a {@link TransformedSource}
+	 * built with the same {@code affine} render the same world-space image for the
+	 * given {@code base}.
+	 * <p>
+	 * Both interpolated sources live in their own pixel frame, so each is lifted
+	 * into world coordinates with {@link RealViews#affine} using that source's
+	 * {@code getSourceTransform}. The comparison walks the world-space footprint of
+	 * the base image (its interval mapped through the {@link TransformedSource}'s
+	 * source transform) and samples both world accessibles there.
+	 */
+	private static void assertSourcesMatch( final RandomAccessibleIntervalSource< DoubleType > base, final AffineTransform3D affine )
+	{
+		final TransformedSource< DoubleType > ts = new TransformedSource<>( base );
+		ts.setFixedTransform( affine );
+
+		final RealTransformedSource< DoubleType > rts = new RealTransformedSource<>( base, "rts", affine );
+
+		// transform interpolated sources into world coordinates
+		final AffineTransform3D tsToWorld = new AffineTransform3D();
+		ts.getSourceTransform( 0, 0, tsToWorld );
+		final RealRandomAccess< DoubleType > tsWorld =
+				RealViews.affine( ts.getInterpolatedSource( 0, 0, Interpolation.NLINEAR ), tsToWorld ).realRandomAccess();
+
+		final AffineTransform3D rtsToWorld = new AffineTransform3D();
+		rts.getSourceTransform( 0, 0, rtsToWorld );
+		final RealRandomAccess< DoubleType > rtsWorld =
+				RealViews.affine( rts.getInterpolatedSource( 0, 0, Interpolation.NLINEAR ), rtsToWorld ).realRandomAccess();
+
+		// test over the the base image's bounds in world coordinates as estimated by tsToWorld
+		final FinalRealInterval worldBounds = tsToWorld.estimateBounds( base.getSource( 0, 0 ) );
+		final double[] steps = { 1, 1, 1 };
+		final LocalizingRealIntervalIterator it = new LocalizingRealIntervalIterator( worldBounds, steps );
+
+		while ( it.hasNext() )
+		{
+			it.fwd();
+			tsWorld.setPosition( it );
+			rtsWorld.setPosition( it );
+			final double vTs = tsWorld.get().get();
+			final double vRts = rtsWorld.get().get();
+			assertEquals( "world: " + it, vTs, vRts, EPSILON );
+		}
+
+	}
+
+	private static RandomAccessibleIntervalSource< DoubleType > exampleImg( final AffineTransform3D calibration )
+	{
+		final long[] dims = { 5, 4, 3 };
+		final ArrayImg< DoubleType, ? > img = ArrayImgs.doubles( dims );
+		final Cursor< DoubleType > c = img.localizingCursor();
+		while ( c.hasNext() )
+		{
+			c.fwd();
+			final int x = c.getIntPosition( 0 );
+			final int y = c.getIntPosition( 1 );
+			final int z = c.getIntPosition( 2 );
+			c.get().set( 1 + x + 5 * y + 20 * z );
+		}
+
+		return new RandomAccessibleIntervalSource<>(img, new DoubleType(), calibration, "base");
+	}
+
+	private static AffineTransform3D exampleAffine()
+	{
+		final AffineTransform3D affine = new AffineTransform3D();
+		affine.scale(  0.8 );
+		affine.translate( 0.2, 0.4, 0.6 );
+		return affine;
+	}
+}

--- a/src/test/java/bdv/tools/transformation/RealTransformedSourceTest.java
+++ b/src/test/java/bdv/tools/transformation/RealTransformedSourceTest.java
@@ -55,7 +55,8 @@ public class RealTransformedSourceTest
 		final TransformedSource< DoubleType > ts = new TransformedSource<>( base );
 		ts.setFixedTransform( affine );
 
-		final RealTransformedSource< DoubleType > rts = new RealTransformedSource<>( base, "rts", affine );
+		// RealTransformedSource uses the inverse transform
+		final RealTransformedSource< DoubleType > rts = new RealTransformedSource<>( base, "rts", affine.inverse() );
 
 		// transform interpolated sources into world coordinates
 		final AffineTransform3D tsToWorld = new AffineTransform3D();


### PR DESCRIPTION
A new version of https://github.com/bigdataviewer/bigdataviewer-core/pull/133 (which I closed), that takes advantage of new bdv and imglib2-realtransform functionality. 

## Summary of the class from the javadoc

> A `Source` that wraps another `Source` and warps it with an `InvertibleRealTransform` applied in world coordinates. This class is intended for use with general, potentially non-affine transformations. For affines, use `TransformedSource`.
> 
> The supplied transform is interpreted in the world coordinate system that the wrapped source maps into via its  `Source#getSourceTransform`.  Since the images returned by `getSource` and `getInterpolatedSource` are expected to be in the  scale levels' pixel coordinates, this class internally maps pixel coordinate to world coordinates before applying the provided transformation, then maps back to pixel coordinates.
> 
> The bounding intervals for each mipmap level are estimated using the passed `boundingBoxEstimator`, using `FacesSteps` with 10  steps as the default. 

## Direction of the transforms

`RealTransformSource` uses the same convention as `TransformedSource` that the "image is transformed by the forward transformation" - meaning that the [inverse transformation is used for rendering.](https://github.com/bigdataviewer/bigdataviewer-core/compare/master...bogovicj:bigdataviewer-core:realTransformedSource#diff-7c7ebf058562b1f944bec36b569b6743c1dccec222da4e4a7f18e5d24538b207R261). The forward transform is used to determine the [bounding box of the transformed image.](https://github.com/bigdataviewer/bigdataviewer-core/compare/master...bogovicj:bigdataviewer-core:realTransformedSource#diff-7c7ebf058562b1f944bec36b569b6743c1dccec222da4e4a7f18e5d24538b207R238). For that reason, the inverse transformation should be fast.  If one direction of the transformation needs to be iteratively estimated, it should be the forward direction.  That may be unintuitive.  I should at least document this better... but there may be other strategies.

### Different convention?

Now, this method takes an `InvertibleRealTransform`, but it perhaps could just take a `RealTransform`.  If we did that:

1. It's convention would differ from `TransformedSource` which might be confusing
2. The bounding box estimation could not be done by this class.

### (2) if no bounding box estimation

This class could take in a collection of `Intervals` which are stored and just used for each level, deferring the bounding box estimation to the caller.  Honestly, right now this class has constructors with arguments

 * `InvertibleRealTransform transform`
 *  `BiFunction<RealTransform, Interval, Interval> boundingBoxEstimator`

but it could *also* have 

 * `RealTransform transform`
 * `List<Interval> boundingBoxes`
